### PR TITLE
Fix term printing in errors to properly show embedded lists

### DIFF
--- a/test/crash.erl
+++ b/test/crash.erl
@@ -22,11 +22,19 @@ handle_call(badfun, _, State) ->
 	{reply, M(), State};
 handle_call(bad_return, _, _) ->
 	bleh;
+handle_call(bad_return_string, _, _) ->
+	{tuple, {tuple, "string"}};
 handle_call(case_clause, _, State) ->
-		case State of
-			goober ->
-				{reply, ok, State}
-		end;
+	case State of
+		goober ->
+			{reply, ok, State}
+	end;
+handle_call(case_clause_string, _, State) ->
+	Foo = atom_to_list(?MODULE),
+	case Foo of
+		State ->
+			{reply, ok, State}
+	end;
 handle_call(if_clause, _, State) ->
 	if State == 1 ->
 			{reply, ok, State}
@@ -56,12 +64,12 @@ handle_call(system_limit, _, State) ->
 	Res = list_to_atom(lists:flatten(lists:duplicate(256, "a"))),
 	{reply, Res, State};
 handle_call(process_limit, _, State) ->
-    %% run with +P 300 to make this crash
-    [erlang:spawn(fun() -> timer:sleep(5000) end) || _ <- lists:seq(0, 500)],
-    {reply, ok, State};
+	%% run with +P 300 to make this crash
+	[erlang:spawn(fun() -> timer:sleep(5000) end) || _ <- lists:seq(0, 500)],
+	{reply, ok, State};
 handle_call(port_limit, _, State) ->
-    [erlang:open_port({spawn, "ls"}, []) || _ <- lists:seq(0, 1024)],
-    {reply, ok, State};
+	[erlang:open_port({spawn, "ls"}, []) || _ <- lists:seq(0, 1024)],
+	{reply, ok, State};
 handle_call(noproc, _, State) ->
 	Res = gen_event:call(foo, bar, baz),
 	{reply, Res, State};

--- a/test/lager_test_backend.erl
+++ b/test/lager_test_backend.erl
@@ -237,12 +237,30 @@ error_logger_redirect_crash_test_() ->
                         ?assertEqual(Expected, lists:flatten(Msg))
                 end
             },
+            {"bad return value with string",
+                fun() ->
+                        Pid = whereis(crash),
+                        crash(bad_return_string),
+                        {_, _, Msg} = pop(),
+                        Expected = lists:flatten(io_lib:format("[error] ~w gen_server crash terminated with reason: bad return value: {tuple,{tuple,\"string\"}}", [Pid])),
+                        ?assertEqual(Expected, lists:flatten(Msg))
+                end
+            },
             {"case clause",
                 fun() ->
                         Pid = whereis(crash),
                         crash(case_clause),
                         {_, _, Msg} = pop(),
                         Expected = lists:flatten(io_lib:format("[error] ~w gen_server crash terminated with reason: no case clause matching {} in crash:handle_call/3", [Pid])),
+                        ?assertEqual(Expected, lists:flatten(Msg))
+                end
+            },
+            {"case clause string",
+                fun() ->
+                        Pid = whereis(crash),
+                        crash(case_clause_string),
+                        {_, _, Msg} = pop(),
+                        Expected = lists:flatten(io_lib:format("[error] ~w gen_server crash terminated with reason: no case clause matching \"crash\" in crash:handle_call/3", [Pid])),
                         ?assertEqual(Expected, lists:flatten(Msg))
                 end
             },
@@ -323,7 +341,7 @@ error_logger_redirect_crash_test_() ->
                         Pid = whereis(crash),
                         crash(badarg2),
                         {_, _, Msg} = pop(),
-                        Expected = lists:flatten(io_lib:format("[error] ~w gen_server crash terminated with reason: bad argument in call to erlang:iolist_to_binary([[102,111,111],bar]) in crash:handle_call/3", [Pid])),
+                        Expected = lists:flatten(io_lib:format("[error] ~w gen_server crash terminated with reason: bad argument in call to erlang:iolist_to_binary([\"foo\",bar]) in crash:handle_call/3", [Pid])),
                         ?assertEqual(Expected, lists:flatten(Msg))
                 end
             },


### PR DESCRIPTION
The ~w formatting used before was not printing lists embedded in other
terms. This change uses trunc_io to print those terms safely and without
potentially introducing linebreaks (like ~p would)
