### PR TITLE
Fix to compile on R13A

### DIFF
--- a/src/lager_trunc_io.erl
+++ b/src/lager_trunc_io.erl
@@ -283,7 +283,7 @@ alist([H|T], Max, #print_options{force_strings=true} = Options) when is_integer(
     {L, Len} = alist(T, Max-1, Options),
     {[H|L], Len + 1};
 alist(_, _, #print_options{force_strings=true}) ->
-    error(badarg);
+    erlang:error(badarg);
 alist(_L, _Max, _Options) ->
     throw(unprintable).
 


### PR DESCRIPTION
This fix is for the following error when compiling on R13A:
src/lager_trunc_io.erl:286: function error/1 undefined
