### PR TITLE
Add compiler and syntax_tools as dependencies

### DIFF
--- a/src/lager.app.src
+++ b/src/lager.app.src
@@ -7,7 +7,9 @@
   {modules, []},
   {applications, [
                   kernel,
-                  stdlib
+                  stdlib,
+                  compiler,
+                  syntax_tools
                  ]},
   {registered, []},
   {mod, {lager_app, []}},


### PR DESCRIPTION
Add compiler and syntax_tools as dependencies in the application resource file for correct releases using Reltool.
