### PR TITLE
R15 support

### DIFF
--- a/src/error_logger_lager_h.erl
+++ b/src/error_logger_lager_h.erl
@@ -262,11 +262,11 @@ format_mfa({M, F, A}) when is_list(A) ->
 format_mfa({M, F, A}) when is_integer(A) ->
     io_lib:format("~w:~w/~w", [M, F, A]);
 format_mfa({M, F, A, Props}) when is_list(Props) ->
-    case {proplists:get_value(file, Props), proplists:get_value(line, Props)} of
-        {undefined, undefined} ->
+    case proplists:get_value(line, Props) of
+        undefined ->
             format_mfa({M, F, A});
-        {File, Line} ->
-            [format_mfa({M, F, A}), io_lib:format(" (~s:~w)", [File, Line])]
+        Line ->
+            [format_mfa({M, F, A}), io_lib:format(" line ~w", [Line])]
     end;
 format_mfa(Other) ->
     io_lib:format("~w", [Other]).

--- a/test/lager_test_backend.erl
+++ b/test/lager_test_backend.erl
@@ -247,13 +247,13 @@ crash(Type) ->
     _ = gen_event:which_handlers(error_logger),
     ok.
 
-test_body(Expected, Actual, File) ->
+test_body(Expected, Actual) ->
     case has_line_numbers() of
         true ->
             FileLine = string:substr(Actual, length(Expected)+1),
             Body = string:substr(Actual, 1, length(Expected)),
             ?assertEqual(Expected, Body),
-            ?assertEqual(File, string:substr(FileLine, 3, length(File)));
+            ?assertEqual(" line ", string:substr(FileLine, 1, 6));
         false ->
             ?assertEqual(Expected, Actual)
     end.
@@ -294,7 +294,6 @@ error_logger_redirect_crash_test_() ->
                         {_, _, Msg} = pop(),
                         Expected = lists:flatten(io_lib:format("[error] ~w gen_server crash terminated with reason: bad return value: bleh", [Pid])),
                         ?assertEqual(Expected, lists:flatten(Msg))
-                        %test_body(Expected, lists:flatten(msg), "test/crash.erl")
                 end
             },
             {"bad return value with string",
@@ -312,7 +311,7 @@ error_logger_redirect_crash_test_() ->
                         crash(case_clause),
                         {_, _, Msg} = pop(),
                         Expected = lists:flatten(io_lib:format("[error] ~w gen_server crash terminated with reason: no case clause matching {} in crash:handle_call/3", [Pid])),
-                        test_body(Expected, lists:flatten(Msg), "test/crash.erl")
+                        test_body(Expected, lists:flatten(Msg))
                 end
             },
             {"case clause string",
@@ -321,7 +320,7 @@ error_logger_redirect_crash_test_() ->
                         crash(case_clause_string),
                         {_, _, Msg} = pop(),
                         Expected = lists:flatten(io_lib:format("[error] ~w gen_server crash terminated with reason: no case clause matching \"crash\" in crash:handle_call/3", [Pid])),
-                        test_body(Expected, lists:flatten(Msg), "test/crash.erl")
+                        test_body(Expected, lists:flatten(Msg))
                 end
             },
             {"function clause",
@@ -330,7 +329,7 @@ error_logger_redirect_crash_test_() ->
                         crash(function_clause),
                         {_, _, Msg} = pop(),
                         Expected = lists:flatten(io_lib:format("[error] ~w gen_server crash terminated with reason: no function clause matching crash:function({})", [Pid])),
-                        test_body(Expected, lists:flatten(Msg), "test/crash.erl")
+                        test_body(Expected, lists:flatten(Msg))
                 end
             },
             {"if clause",
@@ -339,7 +338,7 @@ error_logger_redirect_crash_test_() ->
                         crash(if_clause),
                         {_, _, Msg} = pop(),
                         Expected = lists:flatten(io_lib:format("[error] ~w gen_server crash terminated with reason: no true branch found while evaluating if expression in crash:handle_call/3", [Pid])),
-                        test_body(Expected, lists:flatten(Msg), "test/crash.erl")
+                        test_body(Expected, lists:flatten(Msg))
                 end
             },
             {"try clause",
@@ -348,7 +347,7 @@ error_logger_redirect_crash_test_() ->
                         crash(try_clause),
                         {_, _, Msg} = pop(),
                         Expected = lists:flatten(io_lib:format("[error] ~w gen_server crash terminated with reason: no try clause matching [] in crash:handle_call/3", [Pid])),
-                        test_body(Expected, lists:flatten(Msg), "test/crash.erl")
+                        test_body(Expected, lists:flatten(Msg))
                 end
             },
             {"undefined function",
@@ -357,7 +356,7 @@ error_logger_redirect_crash_test_() ->
                         crash(undef),
                         {_, _, Msg} = pop(),
                         Expected = lists:flatten(io_lib:format("[error] ~w gen_server crash terminated with reason: call to undefined function crash:booger/0 from crash:handle_call/3", [Pid])),
-                        test_body(Expected, lists:flatten(Msg), "test/crash.erl")
+                        test_body(Expected, lists:flatten(Msg))
                 end
             },
             {"bad math",
@@ -366,7 +365,7 @@ error_logger_redirect_crash_test_() ->
                         crash(badarith),
                         {_, _, Msg} = pop(),
                         Expected = lists:flatten(io_lib:format("[error] ~w gen_server crash terminated with reason: bad arithmetic expression in crash:handle_call/3", [Pid])),
-                        test_body(Expected, lists:flatten(Msg), "test/crash.erl")
+                        test_body(Expected, lists:flatten(Msg))
                 end
             },
             {"bad match",
@@ -375,7 +374,7 @@ error_logger_redirect_crash_test_() ->
                         crash(badmatch),
                         {_, _, Msg} = pop(),
                         Expected = lists:flatten(io_lib:format("[error] ~w gen_server crash terminated with reason: no match of right hand value {} in crash:handle_call/3", [Pid])),
-                        test_body(Expected, lists:flatten(Msg), "test/crash.erl")
+                        test_body(Expected, lists:flatten(Msg))
                 end
             },
             {"bad arity",
@@ -384,7 +383,7 @@ error_logger_redirect_crash_test_() ->
                         crash(badarity),
                         {_, _, Msg} = pop(),
                         Expected = lists:flatten(io_lib:format("[error] ~w gen_server crash terminated with reason: fun called with wrong arity of 1 instead of 3 in crash:handle_call/3", [Pid])),
-                        test_body(Expected, lists:flatten(Msg), "test/crash.erl")
+                        test_body(Expected, lists:flatten(Msg))
                 end
             },
             {"bad arg1",
@@ -393,7 +392,7 @@ error_logger_redirect_crash_test_() ->
                         crash(badarg1),
                         {_, _, Msg} = pop(),
                         Expected = lists:flatten(io_lib:format("[error] ~w gen_server crash terminated with reason: bad argument in crash:handle_call/3", [Pid])),
-                        test_body(Expected, lists:flatten(Msg), "test/crash.erl")
+                        test_body(Expected, lists:flatten(Msg))
                 end
             },
             {"bad arg2",
@@ -402,7 +401,7 @@ error_logger_redirect_crash_test_() ->
                         crash(badarg2),
                         {_, _, Msg} = pop(),
                         Expected = lists:flatten(io_lib:format("[error] ~w gen_server crash terminated with reason: bad argument in call to erlang:iolist_to_binary([\"foo\",bar]) in crash:handle_call/3", [Pid])),
-                        test_body(Expected, lists:flatten(Msg), "test/crash.erl")
+                        test_body(Expected, lists:flatten(Msg))
                 end
             },
             {"noproc",
@@ -420,7 +419,7 @@ error_logger_redirect_crash_test_() ->
                         crash(badfun),
                         {_, _, Msg} = pop(),
                         Expected = lists:flatten(io_lib:format("[error] ~w gen_server crash terminated with reason: bad function booger in crash:handle_call/3", [Pid])),
-                        test_body(Expected, lists:flatten(Msg), "test/crash.erl")
+                        test_body(Expected, lists:flatten(Msg))
                 end
             }
 
@@ -718,7 +717,7 @@ error_logger_redirect_test_() ->
                         {_, _, Msg} = pop(),
                         Expected = lists:flatten(io_lib:format("[error] ~p CRASH REPORT Process ~p with 0 neighbours crashed with reason: no function clause matching special_process:foo(bar)",
                                 [Pid, Pid])),
-                        test_body(Expected, lists:flatten(Msg), "test/special_process.erl")
+                        test_body(Expected, lists:flatten(Msg))
                 end
             },
             {"messages should not be generated if they don't satisfy the threshold",


### PR DESCRIPTION
Properly support the new extra parameters for stacktraces which include line numbers. Tests work with both R14 and R15.
