### PR TITLE
binaries with escaped chars are not formatted correctly by ~p

### DIFF
--- a/src/lager_trunc_io.erl
+++ b/src/lager_trunc_io.erl
@@ -358,7 +358,8 @@ escape($\n) -> "\\n";
 escape($\r) -> "\\r";
 escape($\e) -> "\\e";
 escape($\f) -> "\\f";
-escape($\b) -> "\\b".
+escape($\b) -> "\\b";
+escape($\v) -> "\\v".
 
 -ifdef(TEST).
 %%--------------------
@@ -487,6 +488,7 @@ binary_printing_test() ->
     ?assertEqual("<<\"hello\\rworld\">>", lists:flatten(format("~p", [<<"hello\rworld">>], 50))),
     ?assertEqual("<<\"hello\\eworld\">>", lists:flatten(format("~p", [<<"hello\eworld">>], 50))),
     ?assertEqual("<<\"hello\\fworld\">>", lists:flatten(format("~p", [<<"hello\fworld">>], 50))),
+    ?assertEqual("<<\"hello\\vworld\">>", lists:flatten(format("~p", [<<"hello\vworld">>], 50))),
     ?assertEqual("     hello", lists:flatten(format("~10s", [<<"hello">>], 50))),
     ok.
 


### PR DESCRIPTION
See here:

```
(lcmdr_server@127.0.0.1)14> lager:log(error, self(), "~p", [<<"\"foo bar\"">>]).
11:14:41.527 [error] <<""foo bar"">>
```

Also here:

```
$ grep 'foo bar' log/*
log/console.log:2012-04-26 11:14:41.527 [error] <0.338.0> <<""foo bar"">>
log/error.log:2012-04-26 11:14:41.527 [error] <0.338.0> <<""foo bar"">>
```

I would expect to see something more like this:

```
(lcmdr_server@127.0.0.1)15> io:format("~p~n", [<<"\"foo bar\"">>]).             
<<"\"foo bar\"">>
```

The same problem occurs with \ in the binary, but I noticed " first because it's most obvious in JSON strings.

This is the version I've got (should be the latest master):

```
$ (cd deps/lager; git rev-parse HEAD)
7815a88c558d539d4c80c901d75f19c4ebd9367b
```
