### PR TITLE
Use -include instead of -include_lib

### DIFF
--- a/src/lager_default_formatter.erl
+++ b/src/lager_default_formatter.erl
@@ -19,7 +19,7 @@
 %%
 %% Include files
 %%
--include_lib("lager/include/lager.hrl").
+-include("lager.hrl").
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.


### PR DESCRIPTION
As `lager_default_formatter` uses `include_lib` instead of `include`, it's not possible to compile lager from a directory not called "lager" or "lager-VSN":

<pre>
==> Entering directory `/private/tmp/foobar'
==> foobar (compile)
src/lager_default_formatter.erl:22: can't find include lib "lager/include/lager.hrl"
make: *** [compile] Error 1
</pre>


(Unfortunately, our build system has an appetite for inventing names when it checks code out of repositories...)

This patch changes it to use a plain `include` instead.
