### PR TITLE
Specify node in the default formatter

### DIFF
--- a/src/lager_default_formatter.erl
+++ b/src/lager_default_formatter.erl
@@ -78,6 +78,8 @@ output(date,Msg) ->
 output(time,Msg) ->
     {_D, T} = lager_msg:timestamp(Msg),
     T;
+output(node,Msg) ->
+    atom_to_list(node());
 output(severity,Msg) ->
     atom_to_list(lager_msg:severity(Msg));
 output(Prop,Msg) when is_atom(Prop) ->


### PR DESCRIPTION
Sometimes it's needed to log a node where the log event occurs, especially when you log across Erlang cluster. I'm not sure that the proposed changes are in the right place. Please suggest another way if you think it's worth.
