### PR TITLE
Remove erl_opts from rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,3 @@
-{erl_opts, [debug_info]}.
 {erl_first_files, ["src/lager_util.erl"]}.
 
 {cover_enabled, true}.


### PR DESCRIPTION
Parameter erl_opts must be ignored for the dependee projects when
committing. Because its presence here discards the value of the
depender's option while it must be used for compile-time selection of
the dependee configuration, the decision being made by the depender.
