### PR TITLE
Empty registered processes section in lager.app.src.

### DIFF
--- a/src/lager.app.src
+++ b/src/lager.app.src
@@ -9,7 +9,7 @@
                   kernel,
                   stdlib
                  ]},
-  {registered, []},
+  {registered, [lager_sup, lager_event, lager_crash_log, lager_handler_watcher_sup]},
   {mod, {lager_app, []}},
   {env, [
             %% What handlers to install with what arguments


### PR DESCRIPTION
The application resource file does not list the registered names lager will use when started. As far as I can see the list should look like this:

``` erlang
{registered, [lager_sup, lager_event, lager_crash_log, lager_handler_watcher_sup]}
```
