### PR TITLE
Parse transform can't handle `Attr' as a variable

### DIFF
--- a/src/lager_transform.erl
+++ b/src/lager_transform.erl
@@ -107,12 +107,15 @@ transform_statement({call, Line, {remote, _Line1, {atom, _Line2, lager},
                     %% [Format, Args] or [Attr, Format].
                     %% The trace attributes will be a list of tuples, so check
                     %% for that.
-                    case Arg1 of
-                        {cons, _, {tuple, _, _}, _} ->
+                    case {element(1, Arg1), Arg1} of
+                        {_, {cons, _, {tuple, _, _}, _}} ->
                             {concat_lists(Arg1, DefaultAttrs),
                                 Arg2, {atom, Line, none}};
-                        {var, _, _} ->
-                            %% crap, its a variable. look at the second
+                        {Type, _} when Type == var;
+                                       Type == lc;
+                                       Type == call;
+                                       Type == record_field ->
+                            %% crap, its not a literal. look at the second
                             %% argument to see if it is a string
                             case Arg2 of
                                 {string, _, _} ->
@@ -120,7 +123,7 @@ transform_statement({call, Line, {remote, _Line1, {atom, _Line2, lager},
                                         Arg2, {atom, Line, none}};
                                 _ ->
                                     %% not a string, going to have to guess
-                                    %% its the argument list
+                                    %% it's the argument list
                                     {DefaultAttrs, Arg1, Arg2}
                             end;
                         _ ->
@@ -158,10 +161,22 @@ transform_statement(Stmt) ->
     Stmt.
 
 %% concat 2 list ASTs by replacing the terminating [] in A with the contents of B
-concat_lists({var, Line, Name}, B) ->
+concat_lists({var, Line, _Name}=Var, B) ->
     %% concatenating a var with a cons
     {call, Line, {remote, Line, {atom, Line, lists},{atom, Line, flatten}},
-        [{cons, Line, {var, Line, Name}, B}]};
+        [{cons, Line, Var, B}]};
+concat_lists({lc, Line, _Body, _Generator} = LC, B) ->
+    %% concatenating a LC with a cons
+    {call, Line, {remote, Line, {atom, Line, lists},{atom, Line, flatten}},
+        [{cons, Line, LC, B}]};
+concat_lists({call, Line, _Function, _Args} = Call, B) ->
+    %% concatenating a call with a cons
+    {call, Line, {remote, Line, {atom, Line, lists},{atom, Line, flatten}},
+        [{cons, Line, Call, B}]};
+concat_lists({record_field, Line, _Var, _Record, _Field} = Rec, B) ->
+    %% concatenating a record_field with a cons
+    {call, Line, {remote, Line, {atom, Line, lists},{atom, Line, flatten}},
+        [{cons, Line, Rec, B}]};
 concat_lists({nil, _Line}, B) ->
     B;
 concat_lists({cons, Line, Element, Tail}, B) ->

--- a/test/lager_test_backend.erl
+++ b/test/lager_test_backend.erl
@@ -24,6 +24,7 @@
         code_change/3]).
 
 -record(state, {level, buffer, ignored}).
+-record(test, {attrs, format, args}).
 -compile([{parse_transform, lager_transform}]).
 
 -ifdef(TEST).
@@ -210,6 +211,95 @@ lager_test_() ->
                         ok
                 end
             },
+            {"list comprehension inplace of literals in logging statements work",
+                fun() ->
+                        ?assertEqual(0, count()),
+                        Attr = [{a, alpha}, {b, beta}],
+                        Fmt = "format ~p",
+                        Args = [world],
+                        lager:info([{K, atom_to_list(V)} || {K, V} <- Attr], "hello"),
+                        lager:info([{K, atom_to_list(V)} || {K, V} <- Attr], "hello ~p", [{atom, X} || X <- Args]),
+                        lager:info([X || X <- Fmt], [world]),
+                        lager:info("hello ~p", [{atom, X} || X <- Args]),
+                        lager:info([{K, atom_to_list(V)} || {K, V} <- Attr], "hello ~p", [{atom, X} || X <- Args]),
+                        lager:info([{d, delta}, {g, gamma}], Fmt, [{atom, X} || X <- Args]),
+                        ?assertEqual(6, count()),
+                        {_Level, _Time, Message, Metadata}  = pop(),
+                        ?assertMatch([{a, "alpha"}, {b, "beta"}|_], Metadata),
+                        ?assertEqual("hello", lists:flatten(Message)),
+                        {_Level, _Time2, Message2, _Metadata2}  = pop(),
+                        ?assertEqual("hello {atom,world}", lists:flatten(Message2)),
+                        {_Level, _Time3, Message3, _Metadata3}  = pop(),
+                        ?assertEqual("format world", lists:flatten(Message3)),
+                        {_Level, _Time4, Message4, _Metadata4}  = pop(),
+                        ?assertEqual("hello {atom,world}", lists:flatten(Message4)),
+                        {_Level, _Time5, Message5, _Metadata5}  = pop(),
+                        ?assertEqual("hello {atom,world}", lists:flatten(Message5)),
+                        {_Level, _Time6, Message6, Metadata6}  = pop(),
+                        ?assertMatch([{d, delta}, {g, gamma}|_], Metadata6),
+                        ?assertEqual("format {atom,world}", lists:flatten(Message6)),
+                        ok
+                end
+            },
+            {"function calls inplace of literals in logging statements work",
+                fun() ->
+                        ?assertEqual(0, count()),
+                        put(attrs, [{a, alpha}, {b, beta}]),
+                        put(format, "format ~p"),
+                        put(args, [world]),
+                        lager:info(get(attrs), "hello"),
+                        lager:info(get(attrs), "hello ~p", get(args)),
+                        lager:info(get(format), [world]),
+                        lager:info("hello ~p", erlang:get(args)),
+                        lager:info(fun() -> get(attrs) end(), "hello ~p", get(args)),
+                        lager:info([{d, delta}, {g, gamma}], get(format), get(args)),
+                        ?assertEqual(6, count()),
+                        {_Level, _Time, Message, Metadata}  = pop(),
+                        ?assertMatch([{a, alpha}, {b, beta}|_], Metadata),
+                        ?assertEqual("hello", lists:flatten(Message)),
+                        {_Level, _Time2, Message2, _Metadata2}  = pop(),
+                        ?assertEqual("hello world", lists:flatten(Message2)),
+                        {_Level, _Time3, Message3, _Metadata3}  = pop(),
+                        ?assertEqual("format world", lists:flatten(Message3)),
+                        {_Level, _Time4, Message4, _Metadata4}  = pop(),
+                        ?assertEqual("hello world", lists:flatten(Message4)),
+                        {_Level, _Time5, Message5, _Metadata5}  = pop(),
+                        ?assertEqual("hello world", lists:flatten(Message5)),
+                        {_Level, _Time6, Message6, Metadata6}  = pop(),
+                        ?assertMatch([{d, delta}, {g, gamma}|_], Metadata6),
+                        ?assertEqual("format world", lists:flatten(Message6)),
+                        ok
+                end
+            },
+            {"record fields inplace of literals in logging statements work",
+                fun() ->
+                        ?assertEqual(0, count()),
+                        Test = #test{attrs=[{a, alpha}, {b, beta}], format="format ~p", args=[world]},
+                        lager:info(Test#test.attrs, "hello"),
+                        lager:info(Test#test.attrs, "hello ~p", Test#test.args),
+                        lager:info(Test#test.format, [world]),
+                        lager:info("hello ~p", Test#test.args),
+                        lager:info(Test#test.attrs, "hello ~p", Test#test.args),
+                        lager:info([{d, delta}, {g, gamma}], Test#test.format, Test#test.args),
+                        ?assertEqual(6, count()),
+                        {_Level, _Time, Message, Metadata}  = pop(),
+                        ?assertMatch([{a, alpha}, {b, beta}|_], Metadata),
+                        ?assertEqual("hello", lists:flatten(Message)),
+                        {_Level, _Time2, Message2, _Metadata2}  = pop(),
+                        ?assertEqual("hello world", lists:flatten(Message2)),
+                        {_Level, _Time3, Message3, _Metadata3}  = pop(),
+                        ?assertEqual("format world", lists:flatten(Message3)),
+                        {_Level, _Time4, Message4, _Metadata4}  = pop(),
+                        ?assertEqual("hello world", lists:flatten(Message4)),
+                        {_Level, _Time5, Message5, _Metadata5}  = pop(),
+                        ?assertEqual("hello world", lists:flatten(Message5)),
+                        {_Level, _Time6, Message6, Metadata6}  = pop(),
+                        ?assertMatch([{d, delta}, {g, gamma}|_], Metadata6),
+                        ?assertEqual("format world", lists:flatten(Message6)),
+                        ok
+                end
+            },
+
             {"log messages below the threshold are ignored",
                 fun() ->
                         ?assertEqual(0, count()),


### PR DESCRIPTION
Log statements with `Attr` bound to a variable, causes the parse transform to fail with a `function_clause`. To reproduce, try out the following:

```
Attr = [{a, alpha}, {b, beta}],
lager:info(Attr, "Hello ~s", ["world!"]).
```

Crashes during compile with something like the following (cropped).

```
{function_clause, [
  {lager_transform, concat_lists, [
    {var,24,'Attr'}, ...
```

The cause is clear, it is expected that the `DefaultAttrs` can be appended to the passed property list of attributes, so there's no clause for a `var` in `concat_lists`.

**But** - It's already noted in `lager_transform.erl` that transformation of logging statements is ambiguous for calls with arity 3 (2 arguments). Sadly I think it's not only that, but actually also broken for arity 2 if `Attr` is a variable - the match for a property list doesn't work. Actually, Is is at all possible to walk the AST in a parse transform, when the variable is passed from outside the module? To me it seems that this could be the real bringer of bad news.

I like the general idea of lager, having log statements transformed in order to add implicit meta-data, but I think that the way the API is designed right now, it's very hard to support a more _free_ way of using, and abusing, it.

To be on the safe side I guess the API has to use stricter ordering for optional parameters i.e. attributes are always arity 3 and always on the end of the call. Another option could be to use tagged parameters.

Perhaps a solution for lager, and this API version, is to simply amend the documentation and more clearly state that the attributes, must be defined as an inline property list.

Or does someone else have a solution for this?

With kind regards
/O
