### PR TITLE
Switch to notify, not sync_notify.

### DIFF
--- a/src/lager.erl
+++ b/src/lager.erl
@@ -78,7 +78,7 @@ dispatch_log(Severity, Metadata, Format, Args, Size) when is_atom(Severity)->
                                 _ ->
                                     Format
                             end,
-                            gen_event:sync_notify(Pid, {log, lager_msg:new(Msg, Timestamp,
+                            gen_event:notify(Pid, {log, lager_msg:new(Msg, Timestamp,
                                         Severity, Metadata, Destinations)});
                         false ->
                             ok


### PR DESCRIPTION
Despite the commit message on d19d927da6, I can't see how sync_notify
could possibly be faster (at least since OTP-8623), and I'm seeing performance issues when logging.

Now that we are logging asynchronously, we also need to add flushes in
critical places in the tests.
