### PR TITLE
Don't assume the supervisor is a registered process.

### DIFF
--- a/src/error_logger_lager_h.erl
+++ b/src/error_logger_lager_h.erl
@@ -98,13 +98,9 @@ handle_event(Event, State) ->
             case lists:sort(D) of
                 [{errorContext, Ctx}, {offender, Off}, {reason, Reason}, {supervisor, Name}] ->
                     Offender = format_offender(Off),
-                    Name1 = case Name of
-                                {local, N} -> N;
-                                _ -> Name
-                            end,
                     ?LOGFMT(error, Pid,
                         "Supervisor ~w had child ~s exit with reason ~s in context ~w",
-                        [Name1, Offender, format_reason(Reason), Ctx]);
+                        [supervisor_name(Name), Offender, format_reason(Reason), Ctx]);
                 _ ->
                     ?LOGMSG(error, Pid, "SUPERVISOR REPORT " ++ print_silly_list(D))
             end;
@@ -138,7 +134,7 @@ handle_event(Event, State) ->
                     MFA = format_mfa(proplists:get_value(mfargs, Started)),
                     Pid = proplists:get_value(pid, Started),
                     ?LOGFMT(debug, P, "Supervisor ~w started ~s at pid ~w",
-                        [element(2, Name), MFA, Pid]);
+                        [supervisor_name(Name), MFA, Pid]);
                 _ ->
                     ?LOGMSG(info, P, "PROGRESS REPORT " ++ print_silly_list(D))
             end;
@@ -315,3 +311,7 @@ print_silly_list([H|T], Fmt, Acc) ->
 print_val(Val) ->
     {Str, _} = lager_trunc_io:print(Val, 500),
     Str.
+
+
+supervisor_name({local, Name}) -> Name;
+supervisor_name(Name) -> Name.


### PR DESCRIPTION
Lager crashes in `error_logger_lager_h.erl` when reporting about a non-named supervisor.

This patch removes the assumption that the supervisor name is always something like `{local, name}`, as it can also be a pid.
