### PR TITLE
Lager failed after long sleep of computer

### DIFF
--- a/src/lager_sup.erl
+++ b/src/lager_sup.erl
@@ -44,6 +44,8 @@ init([]) ->
     Crash = case application:get_env(lager, crash_log) of
         {ok, undefined} ->
             [];
+        {ok, false} ->
+            [];
         {ok, File} ->
             MaxBytes = case application:get_env(lager, crash_log_msg_size) of
                 {ok, Val} when is_integer(Val) andalso Val > 0 -> Val;


### PR DESCRIPTION
I've started erlang application with lager, closed laptop, opened and saw:

<pre>
06:23:10.131 <0.56.0> gen_server lager_crash_log terminated with reason: bad argument in call to erlang:'++'(false, ".3") in lager_util:rotate_logfile/2 line 198
06:23:10.132 <0.56.0> CRASH REPORT Process lager_crash_log with 0 neighbours exited with reason: bad argument in call to erlang:'++'(false, ".3") in lager_util:rotate_logfile/2 line 198 in gen_server:terminate/6 line 747
06:23:10.133 <0.53.0> Supervisor lager_sup had child lager_crash_log started with lager_crash_log:start_link(false, 16384, 1048576, [{hour,4}], 5) at <0.56.0> exit with reason bad argument in call to erlang:'++'(false, ".3") in lager_util:rotate_logfile/2 line 198 in context child_terminated
</pre>


It is revision e74924208

Is it still a bug and I need to collect more information about it?
