### PR TITLE
Fix unicode string bug

### DIFF
--- a/src/lager_crash_log.erl
+++ b/src/lager_crash_log.erl
@@ -206,8 +206,8 @@ do_log({log, Event}, #state{name=Name, fd=FD, inode=Inode, flap=Flap,
                         lager_stdlib:maybe_utc(erlang:localtime())),
                     Time = [Date, " ", TS," =", ReportStr, "====\n"],
                     NodeSuffix = other_node_suffix(Pid),
-                    Msg = io_lib:format("~s~s~s", [Time, MsgStr, NodeSuffix]),
-                    case file:write(NewFD, Msg) of
+                    Msg = io_lib:format("~s~ts~s", [Time, MsgStr, NodeSuffix]),
+                    case file_write(NewFD, Msg) of
                         {error, Reason} when Flap == false ->
                             ?INT_LOG(error, "Failed to write log message to file ~s: ~s",
                                 [Name, file:format_error(Reason)]),
@@ -229,6 +229,10 @@ do_log({log, Event}, #state{name=Name, fd=FD, inode=Inode, flap=Flap,
             end
     end.
 
+file_write(Fd, Msg) when is_list(Msg) ->
+    file:write(Fd, unicode:characters_to_binary(Msg));
+file_write(Fd, Msg) ->
+    file:write(Fd, Msg).
 
 -ifdef(TEST).
 

--- a/src/lager_file_backend.erl
+++ b/src/lager_file_backend.erl
@@ -145,7 +145,7 @@ write(#state{name=Name, fd=FD, inode=Inode, flap=Flap, size=RotSize,
             write(State, Level, Msg);
         {ok, {NewFD, NewInode, _}} ->
             %% delayed_write doesn't report errors
-            _ = file:write(NewFD, Msg),
+            _ = file_write(NewFD, Msg),
             case Level of
                 _ when Level =< ?ERROR ->
                     %% force a sync on any message at error severity or above
@@ -232,6 +232,11 @@ schedule_rotation(_, undefined) ->
 schedule_rotation(Name, Date) ->
     erlang:send_after(lager_util:calculate_next_rotation(Date) * 1000, self(), {rotate, Name}),
     ok.
+
+file_write(Fd, Msg) when is_list(Msg) ->
+    file:write(Fd, unicode:characters_to_binary(Msg));
+file_write(Fd, Msg) ->
+    file:write(Fd, Msg).
 
 -ifdef(TEST).
 


### PR DESCRIPTION
file:write(Fd, Msg) can't handle unicode list(string) in right way and it makes lager process crash.
