### PR TITLE
fix internal log rotation when check_interval > 0

### DIFF
--- a/src/lager_file_backend.erl
+++ b/src/lager_file_backend.erl
@@ -175,7 +175,7 @@ config_to_id(Config) ->
 
 write(#state{name=Name, fd=FD, inode=Inode, flap=Flap, size=RotSize,
         count=Count} = State, Timestamp, Level, Msg) ->
-    LastCheck = timer:now_diff(os:timestamp(), Timestamp) div 1000,
+    LastCheck = timer:now_diff(Timestamp, State#state.last_check) div 1000,
     case LastCheck >= State#state.check_interval orelse FD == undefined of
         true ->
             %% need to check for rotation


### PR DESCRIPTION
As far as I understand (probably because of a typo like below) time since log rotation was last checked was calculated on a wrong way and it never happened if check_interval > 0.

``` src/lager_file_backend.erl
@@ -132 +132 @@ handle_event({log, Message},
-            {ok,write(State, lager_msg:timestamp(Message), lager_msg:...
+            {ok,write(State, State#state.last_check, lager_msg:...
```

Hope I understand the author's intention correctly.

I think the issue is also present on adt-file-write branch.

I will try to add unit test with delayed mode (all tests currently use check_interval=0)
