### PR TITLE
Fix FORMAT ERROR when format a unicode string

### DIFF
--- a/src/lager_format.erl
+++ b/src/lager_format.erl
@@ -251,7 +251,7 @@ control2($s, [L0], F, Adj, P, Pad, latin1, L) ->
 control2($s, [L0], F, Adj, P, Pad, unicode, L) ->
     List = lager_trunc_io:fprint(unicode:characters_to_list(L0), L, [{force_strings, true}]),
     Res = uniconv(string(List, F, Adj, P, Pad)),
-    {Res, lists:flatlength(Res)}.
+    {Res, unisize(Res)}.
 
 maybe_flatten(X) when is_list(X) ->
     lists:flatten(X);
@@ -266,9 +266,13 @@ make_options([{chomp, Bool}|T], Options) when is_boolean(Bool) ->
 -ifdef(UNICODE_AS_BINARIES).
 uniconv(C) ->
     unicode:characters_to_binary(C,unicode).
+unisize(C) ->
+    byte_size(C).
 -else.
 uniconv(C) ->
     C.
+unisize(C) ->
+    lists:flatlength(C).
 -endif.
 %% Default integer base
 base(none) ->

--- a/src/lager_stdlib.erl
+++ b/src/lager_stdlib.erl
@@ -53,6 +53,8 @@ string_p1([H|T]) when is_list(H) ->
         true -> string_p1(T);
         _    -> false
     end;
+string_p1([H|T]) when is_binary(H) ->
+    string_p1(T);
 string_p1([]) -> true;
 string_p1(_) ->  false.
 


### PR DESCRIPTION
lager doesn't support unicode format, either in FmtStr or in Args. this is mainly because lager_stdlib:string_p/1 can't handle unicode strings. (Rune > 255)

this fix try to make "~ts" format works **when compiled with -D UNICODE_AS_BINARIES**

```
%% current version: 
lager:log(info, self(), [20013,25991,27979,35797]). % error
lager:log(info, self(), "~ts", [[20013,25991,27979,35797]]). % error
%% this fix
lager:log(info, self(), [20013,25991,27979,35797]). % error, not support
lager:log(info, self(), "~ts", [[20013,25991,27979,35797]]). % works
```

[20013,25991,27979,35797] is 中文测试, which means "Chinese Character Test".
