### PR TITLE
Move included_applications to applications in .app.src

### DIFF
--- a/src/error_logger_lager_h.erl
+++ b/src/error_logger_lager_h.erl
@@ -415,7 +415,7 @@ t0() ->
     application:stop(lager),
     application:stop(sasl),
     application:start(sasl),
-    application:start(lager),
+    lager:start(),
     set_high_water(5),
     [error_logger:warning_msg("Foo ~p!", [X]) || X <- lists:seq(1,10)],
     timer:sleep(1000),

--- a/src/lager.app.src
+++ b/src/lager.app.src
@@ -7,10 +7,11 @@
   {modules, []},
   {applications, [
                   kernel,
-                  stdlib
+                  stdlib,
+                  syntax_tools,
+                  goldrush
                  ]},
   {registered, [lager_sup, lager_event, lager_crash_log, lager_handler_watcher_sup]},
-  {included_applications, [syntax_tools, goldrush]},
   {mod, {lager_app, []}},
   {env, [
             %% What handlers to install with what arguments

--- a/src/lager.erl
+++ b/src/lager.erl
@@ -42,7 +42,8 @@
 
 %% @doc Start the application. Mainly useful for using `-s lager' as a command
 %% line switch to the VM to make lager start on boot.
-start() -> start(lager).
+start() ->
+    start(lager).
 
 start(App) ->
     start_ok(App, application:start(App, permanent)).

--- a/src/lager_console_backend.erl
+++ b/src/lager_console_backend.erl
@@ -162,7 +162,7 @@ console_log_test_() ->
                 application:load(lager),
                 application:set_env(lager, handlers, []),
                 application:set_env(lager, error_logger_redirect, false),
-                application:start(lager),
+                lager:start(),
                 whereis(user)
         end,
         fun(User) ->
@@ -378,7 +378,7 @@ set_loglevel_test_() ->
                 application:load(lager),
                 application:set_env(lager, handlers, [{lager_console_backend, info}]),
                 application:set_env(lager, error_logger_redirect, false),
-                application:start(lager)
+                lager:start()
         end,
         fun(_) ->
                 application:stop(lager),

--- a/src/lager_crash_log.erl
+++ b/src/lager_crash_log.erl
@@ -241,7 +241,7 @@ filesystem_test_() ->
                 application:set_env(lager, handlers, [{lager_test_backend, info}]),
                 application:set_env(lager, error_logger_redirect, true),
                 application:unset_env(lager, crash_log),
-                application:start(lager),
+                lager:start(),
                 timer:sleep(100),
                 lager_test_backend:flush()
         end,

--- a/src/lager_file_backend.erl
+++ b/src/lager_file_backend.erl
@@ -458,7 +458,7 @@ filesystem_test_() ->
                 application:set_env(lager, handlers, [{lager_test_backend, info}]),
                 application:set_env(lager, error_logger_redirect, false),
                 application:set_env(lager, async_threshold, undefined),
-                application:start(lager)
+                lager:start()
         end,
         fun(_) ->
                 file:delete("test.log"),
@@ -705,7 +705,7 @@ formatting_test_() ->
                 application:load(lager),
                 application:set_env(lager, handlers, [{lager_test_backend, info}]),
                 application:set_env(lager, error_logger_redirect, false),
-                application:start(lager)
+                lager:start()
         end,
         fun(_) ->
                 file:delete("test.log"),

--- a/src/lager_handler_watcher.erl
+++ b/src/lager_handler_watcher.erl
@@ -123,7 +123,7 @@ reinstall_on_initial_failure_test_() ->
                     application:set_env(lager, handlers, [{lager_test_backend, info}, {lager_crash_backend, [from_now(2), undefined]}]),
                     application:set_env(lager, error_logger_redirect, false),
                     application:unset_env(lager, crash_log),
-                    application:start(lager),
+                    lager:start(),
                     try
                       ?assertEqual(1, lager_test_backend:count()),
                       {_Level, _Time, Message, _Metadata} = lager_test_backend:pop(),
@@ -149,7 +149,7 @@ reinstall_on_runtime_failure_test_() ->
                     application:set_env(lager, handlers, [{lager_test_backend, info}, {lager_crash_backend, [undefined, from_now(5)]}]),
                     application:set_env(lager, error_logger_redirect, false),
                     application:unset_env(lager, crash_log),
-                    application:start(lager),
+                    lager:start(),
                     try
                         ?assertEqual(0, lager_test_backend:count()),
                         ?assert(lists:member(lager_crash_backend, gen_event:which_handlers(lager_event))),

--- a/test/lager_test_backend.erl
+++ b/test/lager_test_backend.erl
@@ -441,7 +441,7 @@ lager_test_() ->
                         ?assertEqual(0, count()),
                         application:stop(lager),
                         application:set_env(lager, traces, [{lager_test_backend, [{foo, bar}], debug}]),
-                        application:start(lager),
+                        lager:start(),
                         lager:debug([{foo, bar}], "hello world"),
                         ?assertEqual(1, count()),
                         application:unset_env(lager, traces),
@@ -555,7 +555,7 @@ setup() ->
     application:load(lager),
     application:set_env(lager, handlers, [{?MODULE, info}]),
     application:set_env(lager, error_logger_redirect, false),
-    application:start(lager),
+    lager:start(),
     gen_event:call(lager_event, ?MODULE, flush).
 
 cleanup(_) ->
@@ -608,7 +608,7 @@ error_logger_redirect_crash_test_() ->
                 application:load(lager),
                 application:set_env(lager, error_logger_redirect, true),
                 application:set_env(lager, handlers, [{?MODULE, error}]),
-                application:start(lager),
+                lager:start(),
                 crash:start()
         end,
 
@@ -655,7 +655,7 @@ error_logger_redirect_test_() ->
                 application:load(lager),
                 application:set_env(lager, error_logger_redirect, true),
                 application:set_env(lager, handlers, [{?MODULE, info}]),
-                application:start(lager),
+                lager:start(),
                 lager:log(error, self(), "flush flush"),
                 timer:sleep(100),
                 gen_event:call(lager_event, ?MODULE, flush)
@@ -1154,7 +1154,7 @@ async_threshold_test_() ->
                 application:set_env(lager, error_logger_redirect, false),
                 application:set_env(lager, async_threshold, 10),
                 application:set_env(lager, handlers, [{?MODULE, info}]),
-                application:start(lager)
+                lager:start()
         end,
         fun(_) ->
                 application:unset_env(lager, async_threshold),


### PR DESCRIPTION
Usage of included_applications is evil as it potentially breaks stuff for any
other applications using syntax_tools or goldrush[1](http://learnyousomeerlang.com/the-count-of-applications#included-applications).
