### PR TITLE
Can't disable periodic file rotation

### DIFF
--- a/src/lager_file_backend.erl
+++ b/src/lager_file_backend.erl
@@ -296,7 +296,7 @@ validate_logfile_proplist([{date, Date}|Tail], Acc) ->
             validate_logfile_proplist(Tail, [{date, Spec}|Acc]);
         {error, _} when Date == "" ->
             %% legacy config allowed blanks
-            validate_logfile_proplist(Tail, Acc);
+            validate_logfile_proplist(Tail, [{date, undefined}|Acc]);
         {error, _} ->
             throw({bad_config, "Invalid rotation date", Date})
     end;


### PR DESCRIPTION
Hi,

In README.md, I found following description about log-file rotation.

> To disable rotation set the size to 0 and the date to "".

I tried the above settings, but log file was rotated in midnight.
(In lager_file_backend.erl, if 'date' value is "", the default value "$D0" will be used instead.)

I want to control file rotation via an external program (not lager).

Is there any schedule which corrects this point ? 
