### PR TITLE
Fixed log rotation hang when file:delete fails.

### DIFF
--- a/src/lager_util.erl
+++ b/src/lager_util.erl
@@ -195,16 +195,18 @@ maybe_utc({Date, {H, M, S, Ms}}) ->
             {Date1, {H1, M1, S1, Ms}}
     end.
 
-%% renames and deletes failing are OK
+%% renames failing are OK
 rotate_logfile(File, 0) ->
-    _ = file:delete(File),
-    ok;
+    file:delete(File);
 rotate_logfile(File, 1) ->
-    _ = file:rename(File, File++".0"),
-    rotate_logfile(File, 0);
+    case file:rename(File, File++".0") of
+        ok ->
+            ok;
+        _ ->
+            rotate_logfile(File, 0)
+    end;
 rotate_logfile(File, Count) ->
-    _ =file:rename(File ++ "." ++ integer_to_list(Count - 2), File ++ "." ++
-        integer_to_list(Count - 1)),
+    _ = file:rename(File ++ "." ++ integer_to_list(Count - 2), File ++ "." ++ integer_to_list(Count - 1)),
     rotate_logfile(File, Count - 1).
 
 format_time() ->


### PR DESCRIPTION
If there are no write permissions on the log folder, attempting to rotate the log files by renaming and deleting the log files will fail. This will cause an infinite loop inside `lager_file_backend:write/4` if the log file's size limit has been reached.

This change modifies `lager_util:rotate_logfile/2` to return the result of modifying the current log file so that the case where the rename/delete fails can be handled.
