### PR TITLE
Clarifying how to disable 'crash_log'

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ the lager application variable `error_logger_redirect' to `false'.
 The error_logger handler will also log more complete error messages (protected
 with use of trunc_io) to a "crash log" which can be referred to for further
 information. The location of the crash log can be specified by the crash_log
-application variable. If undefined it is not written at all.
+application variable. If set to `undefined` it is not written at all.
 
 Messages in the crash log are subject to a maximum message size which can be
 specified via the crash_log_msg_size application variable.


### PR DESCRIPTION
The current set of instructions mention 'crash_log' being left undefined
as a variable to disable it, but when that happens, lager starts it at a
default location.

This commit makes it obvious that the value must explicitly set to
'undefined' in order to disable crash_log.
