### PR TITLE
Added options parameter to lager:trace_file

### DIFF
--- a/src/lager_file_backend.erl
+++ b/src/lager_file_backend.erl
@@ -702,6 +702,18 @@ filesystem_test_() ->
                         {ok, Bin3} = file:read_file("foo.log"),
                         ?assertMatch([_, _, "[error]", _, "Test message\n"], re:split(Bin3, " ", [{return, list}, {parts, 5}]))
                 end
+            },
+            {"tracing with options should work",
+                fun() ->
+                        file:delete("foo.log"),
+                        {ok, _} = lager:trace_file("foo.log", [{module, ?MODULE}], [{size, 20}, {check_interval, 1}]), 
+                        lager:error("Test message"),
+                        lager:error("Test message"),
+                        ?assertNot(filelib:is_regular("foo.log.0")),
+                        lager:error("Test message"),
+                        timer:sleep(10),
+                        ?assert(filelib:is_regular("foo.log.0"))
+                end
             }
         ]
     }.


### PR DESCRIPTION
I've added an additional (optional) parameter to lager:trace_file to allow the various lager_file_backend options to be passed in. The particular one I needed was to specify a rollover size, but this will work for all present and future options.
