### PR TITLE
Set source encoding so R17 compiler doesn't choke on lager_file_backend

### DIFF
--- a/src/lager_file_backend.erl
+++ b/src/lager_file_backend.erl
@@ -1,3 +1,4 @@
+%% -*- coding: latin-1 -*-
 %% Copyright (c) 2011-2012 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,


### PR DESCRIPTION
Commit 2b544c40b11ffe24ca41d32267dfd2011c3b747e added a test that assumes the source is latin-1 encoded. R17 defaults everything to utf8 encoding, so trying to compile lager can result in a message similar to:

```
deps/lager/src/lager_file_backend.erl:503: cannot parse file, giving up
ERROR: compile failed while processing deps/lager: rebar_abort
```

Simply explicitly stating that the source is latin-1 fixes it. I haven't tested on earlier versions of erlang but I assume it's a no-op for anything earlier than R17.
