### PR TITLE
Rework how dialyzer PLTs are built and used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ erl_crash.dump
 .project
 log
 deps
-.lager_combo_dialyzer_plt
+.local_dialyzer_plt

--- a/Makefile
+++ b/Makefile
@@ -15,44 +15,6 @@ clean:
 distclean: clean
 	./rebar delete-deps
 
-test:
-	./rebar compile eunit
+DIALYZER_APPS = kernel stdlib erts sasl eunit syntax_tools compiler crypto
 
-##
-## Doc targets
-##
-docs:
-	./rebar doc
-
-APPS = kernel stdlib erts sasl eunit syntax_tools compiler crypto
-PLT ?= $(HOME)/.riak_combo_dialyzer_plt
-LOCAL_PLT = .lager_combo_dialyzer_plt
-
-${PLT}: compile
-ifneq (,$(wildcard $(PLT)))
-	dialyzer --check_plt --plt $(PLT) --apps $(APPS) && \
-		dialyzer --add_to_plt --plt $(PLT) --output_plt $(PLT) --apps $(APPS) ; test $$? -ne 1
-else
-	dialyzer --build_plt --output_plt $(PLT) --apps $(APPS); test $$? -ne 1
-endif
-
-${LOCAL_PLT}: compile
-ifneq (,$(wildcard $(LOCAL_PLT)))
-	dialyzer --check_plt --plt $(LOCAL_PLT) deps/*/ebin  && \
-		dialyzer --add_to_plt --plt $(LOCAL_PLT) --output_plt $(LOCAL_PLT) deps/*/ebin ; test $$? -ne 1
-else
-	dialyzer --build_plt --output_plt $(LOCAL_PLT) deps/*/ebin ; test $$? -ne 1
-endif
-
-dialyzer: ${PLT} ${LOCAL_PLT}
-	dialyzer -Wunmatched_returns --plts $(PLT) $(LOCAL_PLT) -c ebin
-
-cleanplt:
-	@echo 
-	@echo "Are you sure?  It takes several minutes to re-build."
-	@echo Deleting $(PLT) and $(LOCAL_PLT) in 5 seconds.
-	@echo 
-	sleep 5
-	rm $(PLT)
-	rm $(LOCAL_PLT)
-
+include tools.mk

--- a/tools.mk
+++ b/tools.mk
@@ -1,0 +1,39 @@
+test: compile
+	./rebar eunit skip_deps=true
+
+docs:
+	./rebar doc skip_deps=true
+
+PLT ?= $(HOME)/.riak_combo_dialyzer_plt
+LOCAL_PLT = .local_dialyzer_plt
+DIALYZER_FLAGS ?= -Wunmatched_returns
+
+${PLT}: compile
+ifneq (,$(wildcard $(PLT)))
+	dialyzer --check_plt --plt $(PLT) --apps $(DIALYZER_APPS) && \
+		dialyzer --add_to_plt --plt $(PLT) --output_plt $(PLT) --apps $(DIALYZER_APPS) ; test $$? -ne 1
+else
+	dialyzer --build_plt --output_plt $(PLT) --apps $(DIALYZER_APPS); test $$? -ne 1
+endif
+
+${LOCAL_PLT}: compile
+ifneq (,$(wildcard $(LOCAL_PLT)))
+	dialyzer --check_plt --plt $(LOCAL_PLT) deps/*/ebin  && \
+		dialyzer --add_to_plt --plt $(LOCAL_PLT) --output_plt $(LOCAL_PLT) deps/*/ebin ; test $$? -ne 1
+else
+	dialyzer --build_plt --output_plt $(LOCAL_PLT) deps/*/ebin ; test $$? -ne 1
+endif
+
+dialyzer: ${PLT} ${LOCAL_PLT}
+	@echo "==> $(shell basename $(shell pwd)) (dialyzer)"
+	dialyzer $(DIALYZER_FLAGS) --plts $(PLT) $(LOCAL_PLT) -c ebin
+
+cleanplt:
+	@echo 
+	@echo "Are you sure?  It takes several minutes to re-build."
+	@echo Deleting $(PLT) and $(LOCAL_PLT) in 5 seconds.
+	@echo 
+	sleep 5
+	rm $(PLT)
+	rm $(LOCAL_PLT)
+


### PR DESCRIPTION
This commit splits the PLTs into 2, one for all the required OTP
applications that are in the stdlib, and the other for the rebar
dependancies. Each one is created if it does not exist, then checked for
validity and then --add_to_plt is used to add any missing files (this is
very fast if nothing needs to be added). Then the application is
dialyzed using both PLTs.

The 'combo' PLT which resides in ~ is intended to be used by all of
Riak's deps, so it can grow to cover the set of OTP applications that
Riak depends on. Each project can only specify the ones it cares about.
