### PR TITLE
Don't use the proplists module when decoding error_logger messages

### DIFF
--- a/src/error_logger_lager_h.erl
+++ b/src/error_logger_lager_h.erl
@@ -406,6 +406,8 @@ print_val(Val) ->
     Str.
 
 
+%% @doc Faster than proplists, but with the same API as long as you don't need to
+%% handle bare atom keys
 get_value(Key, Value) ->
     get_value(Key, Value, undefined).
 

--- a/test/trunc_io_eqc.erl
+++ b/test/trunc_io_eqc.erl
@@ -137,7 +137,7 @@ gen_pid() ->
 gen_port() ->
     ?LAZY(begin
               Port = erlang:open_port({spawn, "true"}, []),
-              erlang:port_close(Port),
+              catch(erlang:port_close(Port)),
               Port
           end).
 


### PR DESCRIPTION
Proplist module is a lot slower than lists:keyfind, which is a BIF,
because proplists has to work with 'bare' atoms as well as 2-tuples.

This should marginally improve the throughput when printing many
error_logger messages.
