### PR TITLE
Fixed empty tuple bug in lager:pr/2

### DIFF
--- a/src/lager.erl
+++ b/src/lager.erl
@@ -378,8 +378,10 @@ pr(Record, _) ->
     Record.
 
 zip([FieldName|RecordFields], [FieldValue|Record], Module, ToReturn) ->
-    case  is_tuple(FieldValue) andalso is_atom(element(1, FieldValue))
-           andalso is_record_known(FieldValue, Module) of
+    case   is_tuple(FieldValue) andalso
+           tuple_size(FieldValue) > 0 andalso
+           is_atom(element(1, FieldValue)) andalso
+           is_record_known(FieldValue, Module) of
         false ->
             zip(RecordFields, Record, Module, [{FieldName, FieldValue}|ToReturn]);
         _Else ->

--- a/test/pr_nested_record_test.erl
+++ b/test/pr_nested_record_test.erl
@@ -12,10 +12,10 @@
 
 nested_record_test() ->
     A = #a{field1 = x, field2 = y}, 
-    B = #b{field1 = A, field2 = z},
+    B = #b{field1 = A, field2 = {}},
     Pr_B = lager:pr(B, ?MODULE),
     ?assertEqual({'$lager_record', b,
                     [{field1, {'$lager_record', a,
                                     [{field1, x},{field2, y}]}},
-                     {field2, z}]}, 
+                     {field2, {}}]}, 
                    Pr_B).


### PR DESCRIPTION
Fixed issue with `lager:pr/2` whereby `element(1, ...)` is called on every tuple nested inside a pretty printed record regardless of size.

Modified unit test to test 0 size tuple case.
