### PR TITLE
Fix: correct lager startup in crash_log test

### DIFF
--- a/src/lager_crash_log.erl
+++ b/src/lager_crash_log.erl
@@ -241,7 +241,7 @@ filesystem_test_() ->
                 application:set_env(lager, handlers, [{lager_test_backend, info}]),
                 application:set_env(lager, error_logger_redirect, true),
                 application:unset_env(lager, crash_log),
-                application:start(lager),
+                lager:start(),
                 timer:sleep(100),
                 lager_test_backend:flush()
         end,


### PR DESCRIPTION
Not sure how this succeeds on Travis, but for me this causes the tests in `lager_crash_log` to fail.
