### PR TITLE
Make tests pass on buildbot more of the time

### DIFF
--- a/src/lager_console_backend.erl
+++ b/src/lager_console_backend.erl
@@ -175,6 +175,7 @@ console_log_test_() ->
                 unregister(user),
                 register(user, User),
                 application:stop(lager),
+                application:stop(goldrush),
                 error_logger:tty(true)
         end,
         [
@@ -388,6 +389,7 @@ set_loglevel_test_() ->
         end,
         fun(_) ->
                 application:stop(lager),
+                application:stop(goldrush),
                 error_logger:tty(true)
         end,
         [

--- a/src/lager_crash_log.erl
+++ b/src/lager_crash_log.erl
@@ -253,6 +253,7 @@ filesystem_test_() ->
                 end,
                 file:delete("crash_test.log"),
                 application:stop(lager),
+                application:stop(goldrush),
                 error_logger:tty(true)
         end,
         [

--- a/src/lager_file_backend.erl
+++ b/src/lager_file_backend.erl
@@ -476,6 +476,7 @@ filesystem_test_() ->
                 file:delete("test.log.0"),
                 file:delete("test.log.1"),
                 application:stop(lager),
+                application:stop(goldrush),
                 error_logger:tty(true)
         end,
         [
@@ -607,7 +608,7 @@ filesystem_test_() ->
                         ?assertEqual({ok, <<>>}, file:read_file("test.log")),
                         lager:log(info, self(), "Test message1"),
                         ?assertEqual({ok, <<>>}, file:read_file("test.log")),
-                        timer:sleep(1000),
+                        timer:sleep(2000),
                         {ok, Bin} = file:read_file("test.log"),
                         ?assert(<<>> /= Bin)
                 end
@@ -722,6 +723,7 @@ formatting_test_() ->
                 file:delete("test.log"),
                 file:delete("test2.log"),
                 application:stop(lager),
+                application:stop(goldrush),
                 error_logger:tty(true)
         end,
             [{"Should have two log files, the second prefixed with 2>",

--- a/src/lager_handler_watcher.erl
+++ b/src/lager_handler_watcher.erl
@@ -134,6 +134,7 @@ reinstall_on_initial_failure_test_() ->
                       ?assert(lists:member(lager_crash_backend, gen_event:which_handlers(lager_event)))
                     after
                       application:stop(lager),
+                      application:stop(goldrush),
                       error_logger:tty(true)
                     end
             end
@@ -162,6 +163,7 @@ reinstall_on_runtime_failure_test_() ->
                         ?assertEqual(false, lists:member(lager_crash_backend, gen_event:which_handlers(lager_event)))
                     after
                        application:stop(lager),
+                       application:stop(goldrush),
                        error_logger:tty(true)
                    end
             end

--- a/src/lager_util.erl
+++ b/src/lager_util.erl
@@ -629,6 +629,7 @@ check_trace_test() ->
                 {[{module, '*'}], config_to_mask('!=notice'), anythingbutnotice}
                 ], [])),
     application:stop(lager),
+    application:stop(goldrush),
     ok.
 
 is_loggable_test_() ->


### PR DESCRIPTION
- Stop goldrush application as part of cleanup
- Mindlessly twidde timeouts
- Massage mailboxes
