### PR TITLE
support disable pretty printing records encountered at compile time

### DIFF
--- a/src/lager_transform.erl
+++ b/src/lager_transform.erl
@@ -30,6 +30,8 @@
 %% @private
 parse_transform(AST, Options) ->
     TruncSize = proplists:get_value(lager_truncation_size, Options, ?DEFAULT_TRUNCATION),
+    Enable = proplists:get_value(lager_print_records_flag, Options, true),
+    put(print_records_flag, Enable),
     put(truncation_size, TruncSize),
     erlang:put(records, []),
     %% .app file should either be in the outdir, or the same dir as the source file
@@ -37,7 +39,12 @@ parse_transform(AST, Options) ->
     walk_ast([], AST).
 
 walk_ast(Acc, []) ->
-    insert_record_attribute(Acc);
+    case get(print_records_flag) of
+        true ->
+            insert_record_attribute(Acc);
+        false ->
+            lists:reverse(Acc)
+    end;
 walk_ast(Acc, [{attribute, _, module, {Module, _PmodArgs}}=H|T]) ->
     %% A wild parameterized module appears!
     put(module, Module),


### PR DESCRIPTION
I don't want put record info in beam when our server deploy, and we will not use pretty printing records
