### PR TITLE
Fix compile on Release 17 the right way.

### DIFF
--- a/src/lager_file_backend.erl
+++ b/src/lager_file_backend.erl
@@ -1,4 +1,3 @@
-%% -*- coding: latin-1 -*-
 %% Copyright (c) 2011-2012 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
@@ -502,7 +501,7 @@ filesystem_test_() ->
                 fun() ->
                         %% XXX if this test fails, check that this file is encoded latin-1, not utf-8!
                         gen_event:add_handler(lager_event, lager_file_backend, [{"test.log", info}, {lager_default_formatter}]),
-                        lager:log(error, self(),"~ts", ["LÆÝÎN-ï"]),
+                        lager:log(error, self(),"~ts", [[76, 198, 221, 206, 78, $-, 239]]),
                         {ok, Bin} = file:read_file("test.log"),
                         Pid = pid_to_list(self()),
                         Res = re:split(Bin, " ", [{return, list}, {parts, 5}]),


### PR DESCRIPTION
Change a latin1 sequence so it is given as a list of integers. this avoids the problem entirely
since ASCII has the same representation in both latin1 and in utf-8
