### PR TITLE
fix issue #215: lager.app env overwrites default handlers

### DIFF
--- a/src/lager.app.src
+++ b/src/lager.app.src
@@ -13,14 +13,9 @@
   {registered, [lager_sup, lager_event, lager_crash_log, lager_handler_watcher_sup]},
   {mod, {lager_app, []}},
   {env, [
-            %% What handlers to install with what arguments
-            {handlers, [
-                {lager_console_backend, info},
-                {lager_file_backend, [
-                    {file, "log/error.log"}, {level, error}, {size, 10485760}, {date, "$D0"}, {count, 5}]},
-                {lager_file_backend, [
-                    {file, "log/console.log"}, {level, info}, {size, 10485760}, {date, "$D0"}, {count, 5}]}
-            ]},
+            %% Note: application:start(lager) overwrites previously defined environment variables 
+            %%       thus declaration of default handlers is done at lager_app.erl
+  
             %% What colors to use with what log levels
             {colored, false},
             {colors, [

--- a/src/lager_app.erl
+++ b/src/lager_app.erl
@@ -65,8 +65,8 @@ start(_StartType, _StartArgs) ->
     Handlers = case application:get_env(lager, handlers) of
         undefined ->
             [{lager_console_backend, info},
-                {lager_file_backend, [{"log/error.log", error, 10485760, "", 5},
-                        {"log/console.log", info, 10485760, "", 5}]}];
+             {lager_file_backend, [{file, "log/error.log"},   {level, error}, {size, 10485760}, {date, "$D0"}, {count, 5}]},
+             {lager_file_backend, [{file, "log/console.log"}, {level, info}, {size, 10485760}, {date, "$D0"}, {count, 5}]}];
         {ok, Val} ->
             Val
     end,


### PR DESCRIPTION
the default handlers defined at lager.app overwrites handlers defined previously by application:set_env(lager, handlers, ...) if lager application is started application:start(lager)
