### PR TITLE
lager_common_test_backend

### DIFF
--- a/src/lager_common_test_backend.erl
+++ b/src/lager_common_test_backend.erl
@@ -41,8 +41,8 @@ bounce() ->
 bounce(Level) ->
     application:stop(lager),
     lager:start(),
-    gen_event:add_handler(lager_event, lager_common_test_backend, [error, false]),
-    lager:set_loglevel(lager_common_test_backend, Level),
+    gen_event:add_handler(lager_event, lager_common_test_backend, [Level, false]),
+    %lager:set_loglevel(lager_common_test_backend, Level),
     ok.
 
 -spec(init(integer()|atom()|[term()]) -> {ok, #state{}} | {error, atom()}).


### PR DESCRIPTION
Before every test, just `lager_common_test_backend:bounce(Level)` with the log level of your choice. Every message will be passed along to `ct:pal/1` for your viewing pleasure in the common_test reports. 

Also, you can call `lager_common_test_backend:get_logs/0` to get a list of all log messages this backend has received during your test. You can then search that list for expected log messages.

attn: @vagabond and friends
