### PR TITLE
Discard events where the group leader is from another node

### DIFF
--- a/src/error_logger_lager_h.erl
+++ b/src/error_logger_lager_h.erl
@@ -82,6 +82,8 @@ handle_call({set_high_water, N}, State) ->
 handle_call(_Request, State) ->
     {ok, unknown_call, State}.
 
+handle_event({_Type, GL, _Msg}, State) when node(GL) =/= node() ->
+    {ok, State};
 handle_event(Event, State) ->
     case check_hwm(State) of
         {true, NewState} ->


### PR DESCRIPTION
Erlang's error_logger by default redirects events from processes
which have a group leader in another node to that node. So this
commit changes Lager to simply ignore such events, as done in OTP
event handlers.

Closes #223.
