### PR TITLE
Use encrypted, authenticated, HTTPS over Git for fetching goldrush.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 {erl_first_files, ["src/lager_util.erl"]}.
 {deps, [
         {goldrush, "0\.1\.6",
-            {git, "git://github.com/DeadZen/goldrush.git", {tag, "0.1.6"}}}
+            {git, "https://github.com/DeadZen/goldrush.git", {tag, "0.1.6"}}}
        ]}.
 
 {xref_checks, []}.


### PR DESCRIPTION
This patch shouldn't impact people's CI system as both git:// and
https:// should work nicely without authentication.
