### PR TITLE
Update TravisCI for OTP 18.3 and 19.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 sudo: false
 language: erlang
-notifications:
-  email: eng@basho.com
 otp_release:
-  - 18.2.1
+  - 19.0
+  - 18.3
   - 17.5
   - R16B03-1
   - R15B03


### PR DESCRIPTION
TravisCI now supports testing on 18.3 and 19.0. This PR updates the `.travis.yml` file to run tests against those OTP releases.

Switching to 18.3 instead of 18.2.1 makes sense as that's the release most will be targeting for 18.x
