### PR TITLE
Less lines on console

### DIFF
--- a/src/lager_handler_watcher.erl
+++ b/src/lager_handler_watcher.erl
@@ -128,7 +128,7 @@ install_handler2(Sink, Module, Config) ->
         Error ->
             %% try to reinstall it later
             ?INT_LOG(error, "Lager failed to install handler ~p into"
-               " ~p, retrying later : ~p", [Module, Sink, Error]),
+               " ~p, retrying later :~n  ~100p", [Module, Sink, Error]),
             erlang:send_after(5000, self(), reinstall_handler),
             ok
     end.


### PR DESCRIPTION
I output the lager logs on console and it is flooded with poor formatted outputs
Formatting with `~p` tries to break after 80 chars, so my output looked like this:

```
09:07:23.201 [error] Lager failed to install handler lager_journald_backend into lager_event, retrying later : {'EXIT',
                                                                                       {undef,
                                                                                        [{lager_journald_backend,
                                                                                          init,
                                                                                          [[{level,
                                                                                             debug}]],
                                                                                          []},
                                                                                         {gen_event,
                                                                                          server_add_handler,
                                                                                          4,
                                                                                          [{file,
                                                                                            "gen_event.erl"},
                                                                                           {line,
                                                                                            434}]},
                                                                                         {gen_event,
                                                                                          handle_msg,
                                                                                          5,
                                                                                          [{file,
                                                                                            "gen_event.erl"},
                                                                                           {line,
                                                                                            279}]},
                                                                                         {proc_lib,
                                                                                          init_p_do_apply,
                                                                                          3,
                                                                                          [{file,
                                                                                            "proc_lib.erl"},
                                                                                           {line,
                                                                                            240}]}]}}
```

This commit changes it to 

```
09:18:08.396 [error] Lager failed to install handler lager_journald_backend into lager_event, retrying later :
  {'EXIT',{undef,[{lager_journald_backend,init,[[{level,debug}]],[]},
                  {gen_event,server_add_handler,4,[{file,"gen_event.erl"},{line,434}]},
                  {gen_event,handle_msg,5,[{file,"gen_event.erl"},{line,279}]},
                  {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,240}]}]}}
```

which does not flood the console so fast.
