### PR TITLE
Allow Metadata-only logging

### DIFF
--- a/test/lager_test_backend.erl
+++ b/test/lager_test_backend.erl
@@ -248,6 +248,15 @@ lager_test_() ->
                         ok
                 end
             },
+            {"logging with only metadata works",
+                fun() ->
+                        ?assertEqual(0, count()),
+                        lager:warning([{just, metadata}]),
+                        lager:warning([{just, metadata}, {foo, bar}]),
+                        ?assertEqual(2, count()),
+                        ok
+                end
+            },
             {"variables inplace of literals in logging statements work",
                 fun() ->
                         ?assertEqual(0, count()),


### PR DESCRIPTION
This allows users to log metadata (tuple list) without a format string in lager. For
example `lager:info([{foo, bar}])` instead of `lager:info([{foo,bar}], "")`.