### PR TITLE
Bugfix and separate test files directory.

### DIFF
--- a/test/lager_rotate.erl
+++ b/test/lager_rotate.erl
@@ -1,3 +1,23 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2016-2017 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
 -module(lager_rotate).
 
 -compile(export_all).
@@ -6,54 +26,71 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
+-record(state, {
+    dir     :: string(),
+    log1    :: string(),
+    log1r   :: string(),
+    log2    :: string(),
+    log2r   :: string(),
+    sink    :: string(),
+    sinkr   :: string()
+}).
 
 rotate_test_() ->
     {foreach,
         fun() ->
-                file:write_file("test1.log", ""),
-                file:write_file("test2.log", ""),
-                file:write_file("test3.log", ""),
-                file:delete("test1.log.0"),
-                file:delete("test2.log.0"),
-                file:delete("test3.log.0"),
-                error_logger:tty(false),
-                application:load(lager),
-                application:set_env(lager, handlers, 
-                    [{lager_file_backend, [{file, "test1.log"}, {level, info}]},
-                     {lager_file_backend, [{file, "test2.log"}, {level, info}]}]),
-                application:set_env(lager, extra_sinks,
-                    [{sink_event, 
-                        [{handlers, 
-                            [{lager_file_backend, [{file, "test3.log"}, {level, info}]}]}
-                        ]}]),
-                application:set_env(lager, error_logger_redirect, false),
-                application:set_env(lager, async_threshold, undefined),
-                lager:start()
+            Dir = lager_util:create_test_dir(),
+            Log1 = filename:join(Dir, "test1.log"),
+            Log2 = filename:join(Dir, "test2.log"),
+            Sink = filename:join(Dir, "sink.log"),
+            State = #state{
+                dir     = Dir,
+                log1    = Log1,
+                log1r   = Log1 ++ ".0",
+                log2    = Log2,
+                log2r   = Log2 ++ ".0",
+                sink    = Sink,
+                sinkr   = Sink ++ ".0"
+            },
+            file:write_file(Log1, []),
+            file:write_file(Log2, []),
+            file:write_file(Sink, []),
+
+            error_logger:tty(false),
+            application:load(lager),
+            application:set_env(lager, handlers, [
+                {lager_file_backend, [{file, Log1}, {level, info}]},
+                {lager_file_backend, [{file, Log2}, {level, info}]} ]),
+            application:set_env(lager, extra_sinks, [
+                {sink_event,
+                    [{handlers,
+                        [{lager_file_backend, [{file, Sink}, {level, info}]}]}
+                    ]}]),
+            application:set_env(lager, error_logger_redirect, false),
+            application:set_env(lager, async_threshold, undefined),
+            lager:start(),
+            State
         end,
-        fun(_) ->
-                file:delete("test1.log"),
-                file:delete("test2.log"),
-                file:delete("test3.log"),
-                file:delete("test1.log.0"),
-                file:delete("test2.log.0"),
-                file:delete("test3.log.0"),
-                application:stop(lager),
-                application:stop(goldrush),
-                error_logger:tty(true)
-        end,
-        [{"Rotate single file",
+        fun(#state{dir = Dir}) ->
+            application:stop(lager),
+            application:stop(goldrush),
+            lager_util:delete_test_dir(Dir),
+            error_logger:tty(true)
+        end, [
+        fun(State) ->
+            {"Rotate single file",
             fun() ->
                 lager:log(error, self(), "Test message 1"),
                 lager:log(sink_event, error, self(), "Sink test message 1", []),
-                lager:rotate_handler({lager_file_backend, "test1.log"}),
-                ok = wait_until(fun() -> filelib:is_regular("test1.log.0") end, 10),
+                lager:rotate_handler({lager_file_backend, State#state.log1}),
+                ok = wait_until(fun() -> filelib:is_regular(State#state.log1r) end, 10),
                 lager:log(error, self(), "Test message 2"),
                 lager:log(sink_event, error, self(), "Sink test message 2", []),
-                
-                {ok, File1} = file:read_file("test1.log"),
-                {ok, File2} = file:read_file("test2.log"),
-                {ok, SinkFile} = file:read_file("test3.log"),
-                {ok, File1Old} = file:read_file("test1.log.0"),
+
+                {ok, File1} = file:read_file(State#state.log1),
+                {ok, File2} = file:read_file(State#state.log2),
+                {ok, SinkFile} = file:read_file(State#state.sink),
+                {ok, File1Old} = file:read_file(State#state.log1r),
 
                 have_no_log(File1, <<"Test message 1">>),
                 have_log(File1, <<"Test message 2">>),
@@ -66,19 +103,21 @@ rotate_test_() ->
 
                 have_log(SinkFile, <<"Sink test message 1">>),
                 have_log(SinkFile, <<"Sink test message 2">>)
-            end},
-         {"Rotate sink",
+            end}
+        end,
+        fun(State) ->
+            {"Rotate sink",
             fun() ->
                 lager:log(error, self(), "Test message 1"),
                 lager:log(sink_event, error, self(), "Sink test message 1", []),
                 lager:rotate_sink(sink_event),
-                ok = wait_until(fun() -> filelib:is_regular("test3.log.0") end, 10),
+                ok = wait_until(fun() -> filelib:is_regular(State#state.sinkr) end, 10),
                 lager:log(error, self(), "Test message 2"),
                 lager:log(sink_event, error, self(), "Sink test message 2", []),
-                {ok, File1} = file:read_file("test1.log"),
-                {ok, File2} = file:read_file("test2.log"),
-                {ok, SinkFile} = file:read_file("test3.log"),
-                {ok, SinkFileOld} = file:read_file("test3.log.0"),
+                {ok, File1} = file:read_file(State#state.log1),
+                {ok, File2} = file:read_file(State#state.log2),
+                {ok, SinkFile} = file:read_file(State#state.sink),
+                {ok, SinkFileOld} = file:read_file(State#state.sinkr),
 
                 have_log(File1, <<"Test message 1">>),
                 have_log(File1, <<"Test message 2">>),
@@ -91,21 +130,23 @@ rotate_test_() ->
 
                 have_no_log(SinkFile, <<"Sink test message 1">>),
                 have_log(SinkFile, <<"Sink test message 2">>)
-            end},
-         {"Rotate all",
+            end}
+        end,
+        fun(State) ->
+            {"Rotate all",
             fun() ->
                 lager:log(error, self(), "Test message 1"),
                 lager:log(sink_event, error, self(), "Sink test message 1", []),
                 lager:rotate_all(),
-                ok = wait_until(fun() -> filelib:is_regular("test3.log.0") end, 10),
+                ok = wait_until(fun() -> filelib:is_regular(State#state.sinkr) end, 10),
                 lager:log(error, self(), "Test message 2"),
                 lager:log(sink_event, error, self(), "Sink test message 2", []),
-                {ok, File1} = file:read_file("test1.log"),
-                {ok, File2} = file:read_file("test2.log"),
-                {ok, SinkFile} = file:read_file("test3.log"),
-                {ok, File1Old} = file:read_file("test1.log.0"),
-                {ok, File2Old} = file:read_file("test2.log.0"),
-                {ok, SinkFileOld} = file:read_file("test3.log.0"),
+                {ok, File1} = file:read_file(State#state.log1),
+                {ok, File2} = file:read_file(State#state.log2),
+                {ok, SinkFile} = file:read_file(State#state.sink),
+                {ok, File1Old} = file:read_file(State#state.log1r),
+                {ok, File2Old} = file:read_file(State#state.log2r),
+                {ok, SinkFileOld} = file:read_file(State#state.sinkr),
 
                 have_no_log(File1, <<"Test message 1">>),
                 have_log(File1, <<"Test message 2">>),
@@ -125,7 +166,9 @@ rotate_test_() ->
                 have_log(File2Old, <<"Test message 1">>),
                 have_no_log(File2Old, <<"Test message 2">>)
 
-            end}]}.
+            end}
+        end
+    ]}.
 
 have_log(Data, Log) ->
     {_,_} = binary:match(Data, Log).


### PR DESCRIPTION
* Fix `lager_util:rotate_file_fail_test/0` to use `chmod`, as intended, instead of `chown`.
* Adds functions to create and delete separate directories for test files.
* Change all tests that use temporary files to use the above.

Turn off whitespace diffs to review, as much code has been shifted left to allow sane wrapping within around 100 columns.
