### PR TITLE
Fix async_threshold_test_ and trace_files_test_ flappiness.

### DIFF
--- a/src/lager_util.erl
+++ b/src/lager_util.erl
@@ -22,12 +22,15 @@
 
 -include_lib("kernel/include/file.hrl").
 
--export([levels/0, level_to_num/1, level_to_chr/1,
-        num_to_level/1, config_to_mask/1, config_to_levels/1, mask_to_levels/1,
-        open_logfile/2, ensure_logfile/4, rotate_logfile/2, format_time/0, format_time/1,
-        localtime_ms/0, localtime_ms/1, maybe_utc/1, parse_rotation_date_spec/1,
-        calculate_next_rotation/1, validate_trace/1, check_traces/4, is_loggable/3,
-        trace_filter/1, trace_filter/2, expand_path/1, check_hwm/1, make_internal_sink_name/1]).
+-export([
+    levels/0, level_to_num/1, level_to_chr/1,
+    num_to_level/1, config_to_mask/1, config_to_levels/1, mask_to_levels/1,
+    open_logfile/2, ensure_logfile/4, rotate_logfile/2, format_time/0, format_time/1,
+    localtime_ms/0, localtime_ms/1, maybe_utc/1, parse_rotation_date_spec/1,
+    calculate_next_rotation/1, validate_trace/1, check_traces/4, is_loggable/3,
+    trace_filter/1, trace_filter/2, expand_path/1, check_hwm/1,
+    make_internal_sink_name/1, otp_version/0
+]).
 
 -ifdef(TEST).
 -export([create_test_dir/0, delete_test_dir/1]).
@@ -543,6 +546,18 @@ make_internal_sink_name(lager) ->
     ?DEFAULT_SINK;
 make_internal_sink_name(Sink) ->
     list_to_atom(atom_to_list(Sink) ++ "_lager_event").
+
+-spec otp_version() -> pos_integer().
+%% @doc Return the major version of the current Erlang/OTP runtime as an integer.
+otp_version() ->
+    {Vsn, _} = string:to_integer(
+        case erlang:system_info(otp_release) of
+            [$R | Rel] ->
+                Rel;
+            Rel ->
+                Rel
+        end),
+    Vsn.
 
 -ifdef(TEST).
 

--- a/test/lager_rotate.erl
+++ b/test/lager_rotate.erl
@@ -1,3 +1,23 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2016-2017 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
 -module(lager_rotate).
 
 -compile(export_all).
@@ -6,54 +26,71 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
+-record(state, {
+    dir     :: string(),
+    log1    :: string(),
+    log1r   :: string(),
+    log2    :: string(),
+    log2r   :: string(),
+    sink    :: string(),
+    sinkr   :: string()
+}).
 
 rotate_test_() ->
     {foreach,
         fun() ->
-                file:write_file("test1.log", ""),
-                file:write_file("test2.log", ""),
-                file:write_file("test3.log", ""),
-                file:delete("test1.log.0"),
-                file:delete("test2.log.0"),
-                file:delete("test3.log.0"),
-                error_logger:tty(false),
-                application:load(lager),
-                application:set_env(lager, handlers, 
-                    [{lager_file_backend, [{file, "test1.log"}, {level, info}]},
-                     {lager_file_backend, [{file, "test2.log"}, {level, info}]}]),
-                application:set_env(lager, extra_sinks,
-                    [{sink_event, 
-                        [{handlers, 
-                            [{lager_file_backend, [{file, "test3.log"}, {level, info}]}]}
-                        ]}]),
-                application:set_env(lager, error_logger_redirect, false),
-                application:set_env(lager, async_threshold, undefined),
-                lager:start()
+            Dir = lager_util:create_test_dir(),
+            Log1 = filename:join(Dir, "test1.log"),
+            Log2 = filename:join(Dir, "test2.log"),
+            Sink = filename:join(Dir, "sink.log"),
+            State = #state{
+                dir     = Dir,
+                log1    = Log1,
+                log1r   = Log1 ++ ".0",
+                log2    = Log2,
+                log2r   = Log2 ++ ".0",
+                sink    = Sink,
+                sinkr   = Sink ++ ".0"
+            },
+            file:write_file(Log1, []),
+            file:write_file(Log2, []),
+            file:write_file(Sink, []),
+
+            error_logger:tty(false),
+            application:load(lager),
+            application:set_env(lager, handlers, [
+                {lager_file_backend, [{file, Log1}, {level, info}]},
+                {lager_file_backend, [{file, Log2}, {level, info}]} ]),
+            application:set_env(lager, extra_sinks, [
+                {sink_event,
+                    [{handlers,
+                        [{lager_file_backend, [{file, Sink}, {level, info}]}]}
+                    ]}]),
+            application:set_env(lager, error_logger_redirect, false),
+            application:set_env(lager, async_threshold, undefined),
+            lager:start(),
+            State
         end,
-        fun(_) ->
-                file:delete("test1.log"),
-                file:delete("test2.log"),
-                file:delete("test3.log"),
-                file:delete("test1.log.0"),
-                file:delete("test2.log.0"),
-                file:delete("test3.log.0"),
-                application:stop(lager),
-                application:stop(goldrush),
-                error_logger:tty(true)
-        end,
-        [{"Rotate single file",
+        fun(#state{dir = Dir}) ->
+            application:stop(lager),
+            application:stop(goldrush),
+            lager_util:delete_test_dir(Dir),
+            error_logger:tty(true)
+        end, [
+        fun(State) ->
+            {"Rotate single file",
             fun() ->
                 lager:log(error, self(), "Test message 1"),
                 lager:log(sink_event, error, self(), "Sink test message 1", []),
-                lager:rotate_handler({lager_file_backend, "test1.log"}),
-                ok = wait_until(fun() -> filelib:is_regular("test1.log.0") end, 10),
+                lager:rotate_handler({lager_file_backend, State#state.log1}),
+                ok = wait_until(fun() -> filelib:is_regular(State#state.log1r) end, 10),
                 lager:log(error, self(), "Test message 2"),
                 lager:log(sink_event, error, self(), "Sink test message 2", []),
-                
-                {ok, File1} = file:read_file("test1.log"),
-                {ok, File2} = file:read_file("test2.log"),
-                {ok, SinkFile} = file:read_file("test3.log"),
-                {ok, File1Old} = file:read_file("test1.log.0"),
+
+                {ok, File1} = file:read_file(State#state.log1),
+                {ok, File2} = file:read_file(State#state.log2),
+                {ok, SinkFile} = file:read_file(State#state.sink),
+                {ok, File1Old} = file:read_file(State#state.log1r),
 
                 have_no_log(File1, <<"Test message 1">>),
                 have_log(File1, <<"Test message 2">>),
@@ -66,19 +103,21 @@ rotate_test_() ->
 
                 have_log(SinkFile, <<"Sink test message 1">>),
                 have_log(SinkFile, <<"Sink test message 2">>)
-            end},
-         {"Rotate sink",
+            end}
+        end,
+        fun(State) ->
+            {"Rotate sink",
             fun() ->
                 lager:log(error, self(), "Test message 1"),
                 lager:log(sink_event, error, self(), "Sink test message 1", []),
                 lager:rotate_sink(sink_event),
-                ok = wait_until(fun() -> filelib:is_regular("test3.log.0") end, 10),
+                ok = wait_until(fun() -> filelib:is_regular(State#state.sinkr) end, 10),
                 lager:log(error, self(), "Test message 2"),
                 lager:log(sink_event, error, self(), "Sink test message 2", []),
-                {ok, File1} = file:read_file("test1.log"),
-                {ok, File2} = file:read_file("test2.log"),
-                {ok, SinkFile} = file:read_file("test3.log"),
-                {ok, SinkFileOld} = file:read_file("test3.log.0"),
+                {ok, File1} = file:read_file(State#state.log1),
+                {ok, File2} = file:read_file(State#state.log2),
+                {ok, SinkFile} = file:read_file(State#state.sink),
+                {ok, SinkFileOld} = file:read_file(State#state.sinkr),
 
                 have_log(File1, <<"Test message 1">>),
                 have_log(File1, <<"Test message 2">>),
@@ -91,21 +130,23 @@ rotate_test_() ->
 
                 have_no_log(SinkFile, <<"Sink test message 1">>),
                 have_log(SinkFile, <<"Sink test message 2">>)
-            end},
-         {"Rotate all",
+            end}
+        end,
+        fun(State) ->
+            {"Rotate all",
             fun() ->
                 lager:log(error, self(), "Test message 1"),
                 lager:log(sink_event, error, self(), "Sink test message 1", []),
                 lager:rotate_all(),
-                ok = wait_until(fun() -> filelib:is_regular("test3.log.0") end, 10),
+                ok = wait_until(fun() -> filelib:is_regular(State#state.sinkr) end, 10),
                 lager:log(error, self(), "Test message 2"),
                 lager:log(sink_event, error, self(), "Sink test message 2", []),
-                {ok, File1} = file:read_file("test1.log"),
-                {ok, File2} = file:read_file("test2.log"),
-                {ok, SinkFile} = file:read_file("test3.log"),
-                {ok, File1Old} = file:read_file("test1.log.0"),
-                {ok, File2Old} = file:read_file("test2.log.0"),
-                {ok, SinkFileOld} = file:read_file("test3.log.0"),
+                {ok, File1} = file:read_file(State#state.log1),
+                {ok, File2} = file:read_file(State#state.log2),
+                {ok, SinkFile} = file:read_file(State#state.sink),
+                {ok, File1Old} = file:read_file(State#state.log1r),
+                {ok, File2Old} = file:read_file(State#state.log2r),
+                {ok, SinkFileOld} = file:read_file(State#state.sinkr),
 
                 have_no_log(File1, <<"Test message 1">>),
                 have_log(File1, <<"Test message 2">>),
@@ -125,7 +166,9 @@ rotate_test_() ->
                 have_log(File2Old, <<"Test message 1">>),
                 have_no_log(File2Old, <<"Test message 2">>)
 
-            end}]}.
+            end}
+        end
+    ]}.
 
 have_log(Data, Log) ->
     {_,_} = binary:match(Data, Log).


### PR DESCRIPTION
This PR extends the changes in https://github.com/erlang-lager/lager/pull/384 - it ***may*** be mergeable separately, but has not been tested independently.

Initially, problems with `async_threshold_test_` were thought to be related to newer versions of OTP _and/or_ newer multicore CPUs handling messages more efficiently, thereby preventing automatic transition to synchronous `lager` message handling.

After many experimental changes, it appears that the root problem was pollution of the test environment by previous external tests that don't clean up after themselves properly, so this test now rigorously scrubs its environment before running.  The changes already in place are deemed worthwhile and have been kept.

Timeout issues with `trace_files_test_`, where we don't know how long it will take for updates to be flushed, are also addressed.