### PR TITLE
ranch listener case clause error fix

### DIFF
--- a/src/error_logger_lager_h.erl
+++ b/src/error_logger_lager_h.erl
@@ -189,7 +189,13 @@ log_event(Event, #state{sink=Sink} = State) ->
                         [Ref, _Protocol, Worker, Reason] ->
                             ?LOGFMT(Sink, error, Worker,
                                 "Ranch listener ~p terminated with reason: ~s",
-                                [Ref, format_reason(Reason)])
+                                [Ref, format_reason(Reason)]);
+                        [Worker, {_, Ref, Reason}] ->
+                            ?LOGFMT(Sink, error, Worker,
+                                "Ranch listener ~p terminate with reason: ~s",
+                                [Ref, format_reason(Reason)]);
+                        _ ->
+                            ?LOGFMT(Sink, error, Pid, Fmt, Args)
                     end;
                 {false, "webmachine error"++_} ->
                     %% Webmachine HTTP server error


### PR DESCRIPTION
fix these errors:
11:20:03.653 [error] Lager event handler error_logger_lager_h exited with reason {'EXIT',{{case_clause,[reader,{ack,<0.614.0>,{error,timeout}}]},[{error_logger_lager_h,log_event,2,[{file,"src/error_logger_lager_h.erl"},{line,184}]},{gen_event,server_update,4,[{file,"gen_event.erl"},{line,533}]},{gen_event,server_notify,4,[{file,"gen_event.erl"},{line,515}]},{gen_event,server_notify,4,[{file,"gen_event.erl"},{line,517}]},{gen_event,handle_msg,5,[{file,"gen_event.erl"},{line,256}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,247}]}]}}