### PR TITLE
Travis needs a higher timeout for the async test

### DIFF
--- a/test/lager_test_backend.erl
+++ b/test/lager_test_backend.erl
@@ -1588,7 +1588,7 @@ async_threshold_test_() ->
     end,
     {foreach, Setup, Cleanup, [
         {"async threshold works",
-        fun() ->
+         {timeout, 30, fun() ->
             %% we start out async
             ?assertEqual(true, lager_config:get(async)),
             ?assertEqual([{sync_toggled, 0}],
@@ -1629,7 +1629,7 @@ async_threshold_test_() ->
             %% async is true again now that the mailbox has drained
             ?assertEqual(true, lager_config:get(async)),
             ok
-        end}
+        end}}
     ]}.
 
 % Fire off the stuffers with minimal resource overhead - speed is of the essence.


### PR DESCRIPTION
While the test works fine on a local system, running this test in Travis requires a higher timeout threshold. (There have been consistent test failures on OTP 19 for this test taking too long.)