### PR TITLE
Enable sending console output to standard error

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,29 @@ Features
 * Optional load shedding by setting a high water mark to kill (and reinstall)
   a sink after a configurable cool down timer
 
+Contributing
+------------
+We welcome contributions from the community. We are always excited to get ideas
+for improving lager.
+
+If you are looking for an idea to help out, please take a look at our open
+issues - a number of them are tagged with [Help Wanted](https://github.com/erlang-lager/lager/issues?q=is%3Aopen+is%3Aissue+label%3A%22Help+Wanted%22)
+and [Easy](https://github.com/erlang-lager/lager/issues?q=is%3Aopen+is%3Aissue+label%3AEasy) - some
+of them are tagged as both! We are happy to mentor people get started with any
+of these issues, and they don't need prior discussion.
+
+That being said, before you send large changes please open an issue first to
+discuss the change you'd like to make along with an idea of your proposal to
+implement that change.
+
+### PR guidelines ###
+
+* Large changes without prior discussion are likely to be rejected.
+* Changes without test cases are likely to be rejected.
+* Please use the style of the existing codebase when submitting PRs.
+
+We review PRs and issues at least once a month as described below.
+
 OTP Support Policy
 ------------------
 The lager maintainers intend to support the past three OTP releases from
@@ -42,9 +65,9 @@ or the 2.x branch.
 
 Monthly triage cadence
 ----------------------
-We have (at least) monthly issue and PR triage for lager in the #lager room on the 
+We have (at least) monthly issue and PR triage for lager in the #lager room on the
 [freenode](https://freenode.net) IRC network every third Thursday at 2 pm US/Pacific,
-9 pm UTC. You are welcome to join us there to ask questions about lager or 
+10 pm UTC. You are welcome to join us there to ask questions about lager or
 participate in the triage.
 
 Usage
@@ -103,7 +126,7 @@ your app.config):
 {lager, [
   {log_root, "/var/log/hello"},
   {handlers, [
-    {lager_console_backend, info},
+    {lager_console_backend, [{level, info}],
     {lager_file_backend, [{file, "error.log"}, {level, error}]},
     {lager_file_backend, [{file, "console.log"}, {level, info}]}
   ]}
@@ -168,7 +191,7 @@ will be applied on that sink.
 
           %% Default handlers for lager/lager_event
           {handlers, [
-                      {lager_console_backend, info},
+                      {lager_console_backend, [{level, info}]},
                       {lager_file_backend, [{file, "error.log"}, {level, error}]},
                       {lager_file_backend, [{file, "console.log"}, {level, info}]}
                      ]},
@@ -202,7 +225,8 @@ for the backend:
 ```erlang
 {lager, [
   {handlers, [
-    {lager_console_backend, [info, {lager_default_formatter, [time," [",severity,"] ", message, "\n"]}]},
+    {lager_console_backend, [{level, info}, {formatter, lager_default_formatter},
+      {formatter_config, [time," [",severity,"] ", message, "\n"]}]},
     {lager_file_backend, [{file, "error.log"}, {level, error}, {formatter, lager_default_formatter},
       {formatter_config, [date, " ", time," [",severity,"] ",pid, " ", message, "\n"]}]},
     {lager_file_backend, [{file, "console.log"}, {level, info}]}
@@ -528,7 +552,8 @@ The output will be colored from the first occurrence of the atom color
 in the formatting configuration. For example:
 
 ```erlang
-{lager_console_backend, [info, {lager_default_formatter, [time, color, " [",severity,"] ", message, "\e[0m\r\n"]}]}
+{lager_console_backend, [{level, info}, {formatter, lager_default_formatter},
+  {formatter_config, [time, color, " [",severity,"] ", message, "\e[0m\r\n"]}]]}
 ```
 
 This will make the entire log message, except time, colored. The
@@ -815,6 +840,14 @@ Example Usage:
 
 3.x Changelog
 -------------
+3.4.2 - 26 April 2017
+
+    * Docs: Document how to make lager use UTC timestamps (#405)
+    * Docs: Add a note about our triage cadence.
+    * Docs: Update lager_syslog URL
+    * Docs: Document placeholders for error_logger integration (#404)
+    * Feature: Add hex.pm metadata and full rebar3 support.
+
 3.4.1 - 28 March 2017
 
     * Docs: Added documentation around using lager in the context of elixir applications (#398)

--- a/src/lager_app.erl
+++ b/src/lager_app.erl
@@ -40,7 +40,7 @@
 -define(FILENAMES, '__lager_file_backend_filenames').
 -define(THROTTLE, lager_backend_throttle).
 -define(DEFAULT_HANDLER_CONF,
-        [{lager_console_backend, info},
+        [{lager_console_backend, [{level, info}]},
          {lager_file_backend,
           [{file, "log/error.log"}, {level, error},
            {size, 10485760}, {date, "$D0"}, {count, 5}]

--- a/src/lager_console_backend.erl
+++ b/src/lager_console_backend.erl
@@ -19,11 +19,11 @@
 %% <ul>
 %%    <li>`level' - log level to use</li>
 %%    <li>`use_stderr' - either `true' or `false', defaults to false. If set to true,
-%%                       use standard error to output log messages</li>
+%%                       use standard error to output console log messages</li>
 %%    <li>`formatter' - the module to use when formatting log messages. Defaults to
 %%                      `lager_default_formatter'</li>
 %%    <li>`formatter_config' - the format configuration string. Defaults to
-%%                             time [ severity ] message</li>
+%%                             `time [ severity ] message'</li>
 %% </ul>
 
 -module(lager_console_backend).
@@ -52,21 +52,21 @@
 -define(FORMAT_CONFIG_OFF, [{eol, eol()}]).
 
 -ifdef(TEST).
--define(DEPRECATION(_Msg), ok).
+-define(DEPRECATED(_Msg), ok).
 -else.
--define(DEPRECATION(Msg),
-        io:format(user, "WARNING: This is a deprecated console configuration. Please use \"~p\" instead.", [Msg])).
+-define(DEPRECATED(Msg),
+        io:format(user, "WARNING: This is a deprecated console configuration. Please use \"~w\" instead.~n", [Msg])).
 -endif.
 
 %% @private
 init([Level]) when is_atom(Level) ->
-    ?DEPRECATION([{level, Level}]),
+    ?DEPRECATED([{level, Level}]),
     init([{level, Level}]);
 init([Level, true]) when is_atom(Level) -> % for backwards compatibility
-    ?DEPRECATION([{level, Level}, {formatter_config, [{eol, "\\r\\n\\"}]}]),
+    ?DEPRECATED([{level, Level}, {formatter_config, [{eol, "\\r\\n\\"}]}]),
     init([{level, Level}, {formatter_config, ?FORMAT_CONFIG_OFF}]);
-init([Level,false]) when is_atom(Level) -> % for backwards compatibility
-    ?DEPRECATION([{level, Level}]),
+init([Level, false]) when is_atom(Level) -> % for backwards compatibility
+    ?DEPRECATED([{level, Level}]),
     init([{level, Level}]);
 
 init(Options) when is_list(Options) ->
@@ -113,7 +113,7 @@ init(Options) when is_list(Options) ->
             {error, {fatal, bad_log_level}}
     end;
 init(Level) when is_atom(Level) ->
-    ?DEPRECATION([{level, Level}]),
+    ?DEPRECATED([{level, Level}]),
     init([{level, Level}]);
 init(Other) ->
     {error, {fatal, {bad_console_config, Other}}}.
@@ -445,7 +445,7 @@ set_loglevel_test_() ->
         fun() ->
                 error_logger:tty(false),
                 application:load(lager),
-                application:set_env(lager, handlers, [{lager_console_backend, [{level, info}]),
+                application:set_env(lager, handlers, [{lager_console_backend, [{level, info}]}]),
                 application:set_env(lager, error_logger_redirect, false),
                 lager:start()
         end,


### PR DESCRIPTION
Also rationalized the configuration options for the console backend and adds deprecation warnings for the older configuration styles.

TODO:
- [x] Tests

@Vagabond what would be a good way to test these changes?  We have a little pretend group leader shim in the unit tests. Can we use the same technique for `standard_error`

Addresses #168 