### PR TITLE
Fixes for OTP 20

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -21,7 +21,7 @@
 
 {erl_opts, [
     {lager_extra_sinks, ['__lager_test_sink']},
-    {platform_define, "19", test_statem},
+    {platform_define, "(19|20)", test_statem},
     debug_info,
     report,
     verbose,

--- a/src/error_logger_lager_h.erl
+++ b/src/error_logger_lager_h.erl
@@ -146,7 +146,14 @@ log_event(Event, #state{sink=Sink} = State) ->
             case {FormatRaw, Fmt} of
                 {false, "** Generic server "++_} ->
                     %% gen_server terminate
-                    [Name, _Msg, _State, Reason] = Args,
+                    {Reason, Name} = case Args of
+                                         [N, _Msg, _State, R] ->
+                                             {R, N};
+                                         [N, _Msg, _State, R, _Client, _Stacktrace] ->
+                                             %% OTP 20 crash reports contain the pid of the client and stacktrace
+                                             %% TODO do something with them
+                                             {R, N}
+                                     end,
                     ?CRASH_LOG(Event),
                     {Md, Formatted} = format_reason_md(Reason),
                     ?LOGFMT(Sink, error, [{pid, Pid}, {name, Name} | Md], "gen_server ~w terminated with reason: ~s",

--- a/test/lager_test_backend.erl
+++ b/test/lager_test_backend.erl
@@ -1029,7 +1029,7 @@ crash_fsm_test_() ->
             }
         end,
 
-        TestBody("gen_fsm crash", crash_fsm, "gen_fsm crash_fsm in state state1 terminated with reason: call to undefined function crash_fsm:state1/3 from gen_fsm:handle_msg/7"),
+        TestBody("gen_fsm crash", crash_fsm, "gen_fsm crash_fsm in state state1 terminated with reason: call to undefined function crash_fsm:state1/3 from gen_fsm:handle_msg/"),
         TestBody("gen_statem crash", crash_statem, "gen_statem crash_statem in state state1 terminated with reason: no function clause matching crash_statem:handle")
     ],
 


### PR DESCRIPTION
* Handle new gen_server crash messages that contain client pid and stacktrace
* Update platform define for OTP 20
* Handle arity change in gen_fsm handle_msg