### PR TITLE
Added info about application place holder.

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ call "semi-iolist":
       single letter encoding of the severity level (e.g. `'debug'` -> `$D`)
     * The placeholders `pid`, `file`, `line`, `module`, `function`, and `node`
       will always exist if the parse transform is used.
+    * The placeholder `application` may exist if the parse transform is used.
+      It is dependent on finding the applications `app.src` file.
     * If the error logger integration is used, the placeholder `pid`
       will always exist and the placeholder `name` may exist.
     * Applications can define their own metadata placeholder.


### PR DESCRIPTION
`application` is a metadata placeholder but isn't listed in the documentation. This is pull is to add it to the README