### PR TITLE
support logging with macros per level

### DIFF
--- a/include/lager.hrl
+++ b/include/lager.hrl
@@ -30,11 +30,11 @@
                            {line, ?LINE} | Extras]).
 
 -define(lager_log(Severity, Format, Args, Safety),
-        ?lager_log(?DEFAULT_SINK, Severity, ?METADATA([]), Format, Args,
-             ?DEFAULT_TRUNCATION, Safety)).
+        ?lager_log(?DEFAULT_SINK, Severity, ?METADATA(lager:md()), Format, Args,
+                   ?DEFAULT_TRUNCATION, Safety)).
 -define(lager_log(Severity, Metadata, Format, Args, Safety),
-        ?lager_log(?DEFAULT_SINK, Severity, ?METADATA(Metadata), Format, Args,
-             ?DEFAULT_TRUNCATION, Safety)).
+        ?lager_log(?DEFAULT_SINK, Severity, ?METADATA(Metadata++lager:md()), Format, Args,
+                   ?DEFAULT_TRUNCATION, Safety)).
 
 -define(lager_log(Sink, Severity, Metadata, Format, Args, Size, Safety),
         lager:dispatch_log(Sink, Severity, Metadata, Format, Args, Size, Safety)).

--- a/include/lager.hrl
+++ b/include/lager.hrl
@@ -20,6 +20,48 @@
 -define(DEFAULT_SINK, lager_event).
 -define(ERROR_LOGGER_SINK, error_logger_lager_event).
 
+-define(METADATA(Extras), [{severity, info},
+                           {pid, self()},
+                           {node, node()},
+                           {module, ?MODULE},
+                           {function, ?FUNCTION_NAME},
+                           {function_arity, ?FUNCTION_ARITY},
+                           {file, ?FILE},
+                           {line, ?LINE} | Extras]).
+
+-define(log(Level, Format, Args, Safety),
+        lager:dispatch_log(?DEFAULT_SINK, Level, ?METADATA([]), Format, Args,
+                           ?DEFAULT_TRUNCATION, Safety)).
+-define(log(Level, Metadata, Format, Args, Safety),
+        lager:dispatch_log(?DEFAULT_SINK, Level, ?METADATA(Metadata), Format, Args,
+                           ?DEFAULT_TRUNCATION, Safety)).
+
+-define(debug(Format, Args), ?log(debug, Format, Args, safe)).
+-define(debug(Metadata, Format, Args), ?log(debug, Metadata, Format, Args, safe)).
+
+-define(info(Format, Args), ?log(info, Format, Args, safe)).
+-define(info(Metadata, Format, Args), ?log(info, Metadata, Format, Args, safe)).
+
+-define(notice(Format, Args), ?log(notice, Format, Args, safe)).
+-define(notice(Metadata, Format, Args), ?log(notice, Metadata, Format, Args, safe)).
+
+-define(warning(Format, Args), ?log(warning, Format, Args, safe)).
+-define(warning(Metadata, Format, Args), ?log(warning, Metadata, Format, Args, safe)).
+
+-define(error(Format, Args), ?log(error, Format, Args, safe)).
+-define(error(Metadata, Format, Args), ?log(error, Metadata, Format, Args, safe)).
+
+-define(critical(Format, Args), ?log(critical, Format, Args, safe)).
+-define(critical(Metadata, Format, Args), ?log(critical, Metadata, Format, Args, safe)).
+
+-define(alert(Format, Args), ?log(alert, Format, Args, safe)).
+-define(alert(Metadata, Format, Args), ?log(alert, Metadata, Format, Args, safe)).
+
+-define(emergency(Format, Args), ?log(emergency, Format, Args, safe)).
+-define(emergency(Metadata, Format, Args), ?log(emergency, Metadata, Format, Args, safe)).
+
+-define(none(Format, Args), ?log(none, Format, Args, safe)).
+-define(none(Metadata, Format, Args), ?log(none, Metadata, Format, Args, safe)).
 
 -define(LEVELS,
     [debug, info, notice, warning, error, critical, alert, emergency, none]).

--- a/include/lager.hrl
+++ b/include/lager.hrl
@@ -29,39 +29,42 @@
                            {file, ?FILE},
                            {line, ?LINE} | Extras]).
 
--define(log(Level, Format, Args, Safety),
-        lager:dispatch_log(?DEFAULT_SINK, Level, ?METADATA([]), Format, Args,
-                           ?DEFAULT_TRUNCATION, Safety)).
--define(log(Level, Metadata, Format, Args, Safety),
-        lager:dispatch_log(?DEFAULT_SINK, Level, ?METADATA(Metadata), Format, Args,
-                           ?DEFAULT_TRUNCATION, Safety)).
+-define(lager_log(Severity, Format, Args, Safety),
+        ?lager_log(?DEFAULT_SINK, Severity, ?METADATA([]), Format, Args,
+             ?DEFAULT_TRUNCATION, Safety)).
+-define(lager_log(Severity, Metadata, Format, Args, Safety),
+        ?lager_log(?DEFAULT_SINK, Severity, ?METADATA(Metadata), Format, Args,
+             ?DEFAULT_TRUNCATION, Safety)).
 
--define(debug(Format, Args), ?log(debug, Format, Args, safe)).
--define(debug(Metadata, Format, Args), ?log(debug, Metadata, Format, Args, safe)).
+-define(lager_log(Sink, Severity, Metadata, Format, Args, Size, Safety),
+        lager:dispatch_log(Sink, Severity, Metadata, Format, Args, Size, Safety)).
 
--define(info(Format, Args), ?log(info, Format, Args, safe)).
--define(info(Metadata, Format, Args), ?log(info, Metadata, Format, Args, safe)).
+-define(lager_debug(Format, Args), ?lager_log(debug, Format, Args, safe)).
+-define(lager_debug(Metadata, Format, Args), ?lager_log(debug, Metadata, Format, Args, safe)).
 
--define(notice(Format, Args), ?log(notice, Format, Args, safe)).
--define(notice(Metadata, Format, Args), ?log(notice, Metadata, Format, Args, safe)).
+-define(lager_info(Format, Args), ?lager_log(info, Format, Args, safe)).
+-define(lager_info(Metadata, Format, Args), ?lager_log(info, Metadata, Format, Args, safe)).
 
--define(warning(Format, Args), ?log(warning, Format, Args, safe)).
--define(warning(Metadata, Format, Args), ?log(warning, Metadata, Format, Args, safe)).
+-define(lager_notice(Format, Args), ?lager_log(notice, Format, Args, safe)).
+-define(lager_notice(Metadata, Format, Args), ?lager_log(notice, Metadata, Format, Args, safe)).
 
--define(error(Format, Args), ?log(error, Format, Args, safe)).
--define(error(Metadata, Format, Args), ?log(error, Metadata, Format, Args, safe)).
+-define(lager_warning(Format, Args), ?lager_log(warning, Format, Args, safe)).
+-define(lager_warning(Metadata, Format, Args), ?lager_log(warning, Metadata, Format, Args, safe)).
 
--define(critical(Format, Args), ?log(critical, Format, Args, safe)).
--define(critical(Metadata, Format, Args), ?log(critical, Metadata, Format, Args, safe)).
+-define(lager_error(Format, Args), ?lager_log(error, Format, Args, safe)).
+-define(lager_error(Metadata, Format, Args), ?lager_log(error, Metadata, Format, Args, safe)).
 
--define(alert(Format, Args), ?log(alert, Format, Args, safe)).
--define(alert(Metadata, Format, Args), ?log(alert, Metadata, Format, Args, safe)).
+-define(lager_critical(Format, Args), ?lager_log(critical, Format, Args, safe)).
+-define(lager_critical(Metadata, Format, Args), ?lager_log(critical, Metadata, Format, Args, safe)).
 
--define(emergency(Format, Args), ?log(emergency, Format, Args, safe)).
--define(emergency(Metadata, Format, Args), ?log(emergency, Metadata, Format, Args, safe)).
+-define(lager_alert(Format, Args), ?lager_log(alert, Format, Args, safe)).
+-define(lager_alert(Metadata, Format, Args), ?lager_log(alert, Metadata, Format, Args, safe)).
 
--define(none(Format, Args), ?log(none, Format, Args, safe)).
--define(none(Metadata, Format, Args), ?log(none, Metadata, Format, Args, safe)).
+-define(lager_emergency(Format, Args), ?lager_log(emergency, Format, Args, safe)).
+-define(lager_emergency(Metadata, Format, Args), ?lager_log(emergency, Metadata, Format, Args, safe)).
+
+-define(lager_none(Format, Args), ?lager_log(none, Format, Args, safe)).
+-define(lager_none(Metadata, Format, Args), ?lager_log(none, Metadata, Format, Args, safe)).
 
 -define(LEVELS,
     [debug, info, notice, warning, error, critical, alert, emergency, none]).

--- a/test/lager_test_backend.erl
+++ b/test/lager_test_backend.erl
@@ -188,6 +188,16 @@ lager_test_() ->
                         ok
                 end
             },
+            {"logging with macro works",
+                fun() ->
+                        ?warning("test message", []),
+                        ?assertEqual(1, count()),
+                        {Level, _Time, Message, _Metadata}  = pop(),
+                        ?assertMatch(Level, lager_util:level_to_num(warning)),
+                        ?assertEqual("test message", Message),
+                        ok
+                end
+            },
             {"unsafe logging works",
                 fun() ->
                         lager:warning_unsafe("test message"),
@@ -201,6 +211,16 @@ lager_test_() ->
             {"logging with arguments works",
                 fun() ->
                         lager:warning("test message ~p", [self()]),
+                        ?assertEqual(1, count()),
+                        {Level, _Time, Message,_Metadata}  = pop(),
+                        ?assertMatch(Level, lager_util:level_to_num(warning)),
+                        ?assertEqual(lists:flatten(io_lib:format("test message ~p", [self()])), lists:flatten(Message)),
+                        ok
+                end
+            },
+            {"logging with macro and arguments works",
+                fun() ->
+                        ?warning("test message ~p", [self()]),
                         ?assertEqual(1, count()),
                         {Level, _Time, Message,_Metadata}  = pop(),
                         ?assertMatch(Level, lager_util:level_to_num(warning)),

--- a/test/lager_test_backend.erl
+++ b/test/lager_test_backend.erl
@@ -190,7 +190,7 @@ lager_test_() ->
             },
             {"logging with macro works",
                 fun() ->
-                        ?warning("test message", []),
+                        ?lager_warning("test message", []),
                         ?assertEqual(1, count()),
                         {Level, _Time, Message, _Metadata}  = pop(),
                         ?assertMatch(Level, lager_util:level_to_num(warning)),
@@ -220,7 +220,7 @@ lager_test_() ->
             },
             {"logging with macro and arguments works",
                 fun() ->
-                        ?warning("test message ~p", [self()]),
+                        ?lager_warning("test message ~p", [self()]),
                         ?assertEqual(1, count()),
                         {Level, _Time, Message,_Metadata}  = pop(),
                         ?assertMatch(Level, lager_util:level_to_num(warning)),


### PR DESCRIPTION
With new macros being supported in OTP it makes sense to provide a macro interface to lager as well.

There are still some forms of these functions I need to support, like `?info_unsafe`? I stopped here to check that this was an acceptable change upstream and if so that the api was what you'd want.