### PR TITLE
Dont flush notify msgs at overload

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,24 @@ related processes crash, you can set a limit:
 
 It is probably best to keep this number small.
 
+### Event queue flushing
+
+When the high-water mark is exceeded, lager can be configured to flush all
+event notifications in the message queue. This can have unintended consequences
+for other handlers in the same event manager (in e.g. the `error_logger'), as
+events they rely on may be wrongly discarded. By default, this behavior is disabled,
+but can be controlled, for the `error_logger' via:
+
+```erlang
+{error_logger_flush_queue, true | false}
+```
+
+or for a specific sink, using the option:
+
+```erlang
+{flush_queue, true | false}
+```
+
 ### Sink Killer
 
 In some high volume situations, it may be preferable to drop all pending log

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ It is probably best to keep this number small.
 When the high-water mark is exceeded, lager can be configured to flush all
 event notifications in the message queue. This can have unintended consequences
 for other handlers in the same event manager (in e.g. the `error_logger'), as
-events they rely on may be wrongly discarded. By default, this behavior is disabled,
+events they rely on may be wrongly discarded. By default, this behavior is enabled,
 but can be controlled, for the `error_logger' via:
 
 ```erlang
@@ -372,6 +372,21 @@ or for a specific sink, using the option:
 
 ```erlang
 {flush_queue, true | false}
+
+If `flush_queue` is true, a message queue length threshold can be set, at which
+messages will start being discarded. The default threshold is `0`, meaning that
+if `flush_queue` is true, messages will be discarded if the high-water mark is
+exceeded, regardless of the length of the message queue. The option to control
+the threshold is, for `error_logger`:
+
+```erlang
+{error_logger_flush_threshold, 1000}
+```
+
+and for sinks:
+
+```erlang
+{flush_threshold, 1000}
 ```
 
 ### Sink Killer

--- a/include/lager.hrl
+++ b/include/lager.hrl
@@ -121,6 +121,8 @@
                   lasttime = os:timestamp() :: erlang:timestamp(),
                   %% count of dropped messages this second
                   dropped = 0 :: non_neg_integer(),
+                  %% If true, flush notify messages from msg queue at overload
+                  flush_queue = false :: boolean(),
                   %% timer
                   timer = make_ref() :: reference(),
                   %% optional filter fun to avoid counting suppressed messages against HWM totals

--- a/include/lager.hrl
+++ b/include/lager.hrl
@@ -122,7 +122,8 @@
                   %% count of dropped messages this second
                   dropped = 0 :: non_neg_integer(),
                   %% If true, flush notify messages from msg queue at overload
-                  flush_queue = false :: boolean(),
+                  flush_queue = true :: boolean(),
+                  flush_threshold = 0 :: integer(),
                   %% timer
                   timer = make_ref() :: reference(),
                   %% optional filter fun to avoid counting suppressed messages against HWM totals

--- a/src/error_logger_lager_h.erl
+++ b/src/error_logger_lager_h.erl
@@ -72,7 +72,8 @@ set_high_water(N) ->
 
 -spec init(any()) -> {ok, #state{}}.
 init([HighWaterMark, GlStrategy]) ->
-    Shaper = #lager_shaper{hwm=HighWaterMark, filter=shaper_fun(), id=?MODULE},
+    Flush = lager_app:get_env(lager, error_logger_flush_queue, false),
+    Shaper = #lager_shaper{hwm=HighWaterMark, flush_queue = Flush, filter=shaper_fun(), id=?MODULE},
     Raw = lager_app:get_env(lager, error_logger_format_raw, false),
     Sink = configured_sink(),
     {ok, #state{sink=Sink, shaper=Shaper, groupleader_strategy=GlStrategy, raw=Raw}}.

--- a/src/error_logger_lager_h.erl
+++ b/src/error_logger_lager_h.erl
@@ -73,7 +73,8 @@ set_high_water(N) ->
 -spec init(any()) -> {ok, #state{}}.
 init([HighWaterMark, GlStrategy]) ->
     Flush = lager_app:get_env(lager, error_logger_flush_queue, false),
-    Shaper = #lager_shaper{hwm=HighWaterMark, flush_queue = Flush, filter=shaper_fun(), id=?MODULE},
+    FlushThr = lager_app:get_env(lager, error_logger_flush_threshold, 0),
+    Shaper = #lager_shaper{hwm=HighWaterMark, flush_queue = Flush, flush_threshold = FlushThr, filter=shaper_fun(), id=?MODULE},
     Raw = lager_app:get_env(lager, error_logger_format_raw, false),
     Sink = configured_sink(),
     {ok, #state{sink=Sink, shaper=Shaper, groupleader_strategy=GlStrategy, raw=Raw}}.

--- a/src/lager_file_backend.erl
+++ b/src/lager_file_backend.erl
@@ -108,11 +108,11 @@ init(LogFileConfig) when is_list(LogFileConfig) ->
             {error, {fatal, bad_config}};
         Config ->
             %% probabably a better way to do this, but whatever
-            [RelName, Level, Date, Size, Count, HighWaterMark, SyncInterval, SyncSize, SyncOn, CheckInterval, Formatter, FormatterConfig] =
-              [proplists:get_value(Key, Config) || Key <- [file, level, date, size, count, high_water_mark, sync_interval, sync_size, sync_on, check_interval, formatter, formatter_config]],
+            [RelName, Level, Date, Size, Count, HighWaterMark, Flush, SyncInterval, SyncSize, SyncOn, CheckInterval, Formatter, FormatterConfig] =
+              [proplists:get_value(Key, Config) || Key <- [file, level, date, size, count, high_water_mark, flush_queue, sync_interval, sync_size, sync_on, check_interval, formatter, formatter_config]],
             Name = lager_util:expand_path(RelName),
             schedule_rotation(Name, Date),
-            Shaper = #lager_shaper{hwm=HighWaterMark, id=Name},
+            Shaper = lager_util:maybe_flush(Flush, #lager_shaper{hwm=HighWaterMark, id=Name}),
             State0 = #state{name=Name, level=Level, size=Size, date=Date, count=Count, shaper=Shaper, formatter=Formatter,
                 formatter_config=FormatterConfig, sync_on=SyncOn, sync_interval=SyncInterval, sync_size=SyncSize,
                 check_interval=CheckInterval},

--- a/src/lager_file_backend.erl
+++ b/src/lager_file_backend.erl
@@ -110,9 +110,10 @@ init(LogFileConfig) when is_list(LogFileConfig) ->
             %% probabably a better way to do this, but whatever
             [RelName, Level, Date, Size, Count, HighWaterMark, Flush, SyncInterval, SyncSize, SyncOn, CheckInterval, Formatter, FormatterConfig] =
               [proplists:get_value(Key, Config) || Key <- [file, level, date, size, count, high_water_mark, flush_queue, sync_interval, sync_size, sync_on, check_interval, formatter, formatter_config]],
+            FlushThr = proplists:get_value(flush_threshold, Config, 0),
             Name = lager_util:expand_path(RelName),
             schedule_rotation(Name, Date),
-            Shaper = lager_util:maybe_flush(Flush, #lager_shaper{hwm=HighWaterMark, id=Name}),
+            Shaper = lager_util:maybe_flush(Flush, #lager_shaper{hwm=HighWaterMark, flush_threshold = FlushThr, id=Name}),
             State0 = #state{name=Name, level=Level, size=Size, date=Date, count=Count, shaper=Shaper, formatter=Formatter,
                 formatter_config=FormatterConfig, sync_on=SyncOn, sync_interval=SyncInterval, sync_size=SyncSize,
                 check_interval=CheckInterval},

--- a/src/lager_util.erl
+++ b/src/lager_util.erl
@@ -556,39 +556,17 @@ check_hwm(Shaper = #lager_shaper{lasttime = Last, dropped = Drop}) ->
     case Last of
         {M, S, N} ->
             %% still in same second, but have exceeded the high water mark
-            NewDrops = discard_messages(Now, Shaper#lager_shaper.filter, 0),
             Timer = case erlang:read_timer(Shaper#lager_shaper.timer) of
                         false ->
                             erlang:send_after(trunc((1000000 - N)/1000), self(), {shaper_expired, Shaper#lager_shaper.id});
                         _ ->
                             Shaper#lager_shaper.timer
                     end,
-            {false, 0, Shaper#lager_shaper{dropped=Drop+NewDrops, timer=Timer}};
+            {false, 0, Shaper#lager_shaper{dropped=Drop+1, timer=Timer}};
         _ ->
             erlang:cancel_timer(Shaper#lager_shaper.timer),
             %% different second, reset all counters and allow it
             {true, Drop, Shaper#lager_shaper{dropped = 0, mps=1, lasttime = Now}}
-    end.
-
-discard_messages(Second, Filter, Count) ->
-    {M, S, _} = os:timestamp(),
-    case Second of
-        {M, S, _} ->
-            receive
-                %% we only discard gen_event notifications, because
-                %% otherwise we might discard gen_event internal
-                %% messages, such as trapped EXITs
-                {notify, Event} ->
-                    NewCount = case Filter(Event) of
-                                   false -> Count+1;
-                                   true -> Count
-                               end,
-                    discard_messages(Second, Filter, NewCount)
-            after 0 ->
-                    Count
-            end;
-        _ ->
-            Count
     end.
 
 %% @private Build an atom for the gen_event process based on a sink name.


### PR DESCRIPTION
We've been chasing weird timeout bugs in our test suites, presumably due to race conditions, but recently realized that lager was hitting the high-water mark and actually _deleting_ `app_started` events that our test suite depended on. This behavior violates the Principle of Least Surprise, to say the least.

In the interest of backward compatibility, I've made the behavior configurable, for `error_logger` and for each sink. I have, though, chosen the b/w incompatible default of _not_ flushing events. As long as it's properly documented and configurable, which should be the default can of course be discussed.