### PR TITLE
Remove code which supports R15

### DIFF
--- a/src/error_logger_lager_h.erl
+++ b/src/error_logger_lager_h.erl
@@ -72,10 +72,10 @@ set_high_water(N) ->
 
 -spec init(any()) -> {ok, #state{}}.
 init([HighWaterMark, GlStrategy]) ->
-    Flush = lager_app:get_env(lager, error_logger_flush_queue, false),
-    FlushThr = lager_app:get_env(lager, error_logger_flush_threshold, 0),
+    Flush = application:get_env(lager, error_logger_flush_queue, false),
+    FlushThr = application:get_env(lager, error_logger_flush_threshold, 0),
     Shaper = #lager_shaper{hwm=HighWaterMark, flush_queue = Flush, flush_threshold = FlushThr, filter=shaper_fun(), id=?MODULE},
-    Raw = lager_app:get_env(lager, error_logger_format_raw, false),
+    Raw = application:get_env(lager, error_logger_format_raw, false),
     Sink = configured_sink(),
     {ok, #state{sink=Sink, shaper=Shaper, groupleader_strategy=GlStrategy, raw=Raw}}.
 
@@ -86,7 +86,7 @@ handle_call(_Request, State) ->
     {ok, unknown_call, State}.
 
 shaper_fun() ->
-    case {lager_app:get_env(lager, suppress_supervisor_start_stop, false), lager_app:get_env(lager, suppress_application_start_stop, false)} of
+    case {application:get_env(lager, suppress_supervisor_start_stop, false), application:get_env(lager, suppress_application_start_stop, false)} of
         {false, false} ->
             fun(_) -> false end;
         {true, true} ->
@@ -138,7 +138,7 @@ terminate(_Reason, _State) ->
 
 
 code_change(_OldVsn, {state, Shaper, GLStrategy}, _Extra) ->
-    Raw = lager_app:get_env(lager, error_logger_format_raw, false),
+    Raw = application:get_env(lager, error_logger_format_raw, false),
     {ok, #state{
         sink=configured_sink(),
         shaper=Shaper,
@@ -146,7 +146,7 @@ code_change(_OldVsn, {state, Shaper, GLStrategy}, _Extra) ->
         raw=Raw
         }};
 code_change(_OldVsn, {state, Sink, Shaper, GLS}, _Extra) ->
-    Raw = lager_app:get_env(lager, error_logger_format_raw, false),
+    Raw = application:get_env(lager, error_logger_format_raw, false),
     {ok, #state{sink=Sink, shaper=Shaper, groupleader_strategy=GLS, raw=Raw}};
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
@@ -154,7 +154,7 @@ code_change(_OldVsn, State, _Extra) ->
 %% internal functions
 
 configured_sink() ->
-    case proplists:get_value(?ERROR_LOGGER_SINK, lager_app:get_env(lager, extra_sinks, [])) of
+    case proplists:get_value(?ERROR_LOGGER_SINK, application:get_env(lager, extra_sinks, [])) of
         undefined -> ?DEFAULT_SINK;
         _ -> ?ERROR_LOGGER_SINK
     end.
@@ -324,7 +324,7 @@ log_event(Event, #state{sink=Sink} = State) ->
                                     [App, Node])
                     end;
                 [{started, Started}, {supervisor, Name}] ->
-                    case lager_app:get_env(lager, suppress_supervisor_start_stop, false) of
+                    case application:get_env(lager, suppress_supervisor_start_stop, false) of
                         true ->
                             ok;
                         _ ->

--- a/src/lager.erl
+++ b/src/lager.erl
@@ -624,18 +624,9 @@ pr_stacktrace(Stacktrace, {Class, Reason}) ->
               io_lib:format("~s:~p", [Class, Reason]) ++ pr_stacktrace_(Stacktrace))
     end.
 
-%% R15 compatibility only
-filtermap(Fun, List1) ->
-    lists:foldr(fun(Elem, Acc) ->
-                       case Fun(Elem) of
-                           false -> Acc;
-                           {true,Value} -> [Value|Acc]
-                       end
-                end, [], List1).
-
 rotate_sink(Sink) ->
     Handlers = lager_config:global_get(handlers),
-    RotateHandlers = filtermap(
+    RotateHandlers = lists:filtermap(
         fun({Handler,_,S}) when S == Sink -> {true, {Handler, Sink}};
            (_)                            -> false 
         end, 

--- a/src/lager_stdlib.erl
+++ b/src/lager_stdlib.erl
@@ -83,7 +83,7 @@ maybe_utc(Time) ->
             Val;
         undefined ->
             %% Backwards compatible:
-            lager_app:get_env(stdlib, utc_log, false)
+            application:get_env(stdlib, utc_log, false)
     end,
     if
         UTC =:= true ->

--- a/src/lager_sup.erl
+++ b/src/lager_sup.erl
@@ -45,7 +45,7 @@ init([]) ->
         {lager_handler_watcher_sup, {lager_handler_watcher_sup, start_link, []},
             permanent, 5000, supervisor, [lager_handler_watcher_sup]}],
 
-    CrashLog = decide_crash_log(lager_app:get_env(lager, crash_log, false)),
+    CrashLog = decide_crash_log(application:get_env(lager, crash_log, false)),
 
     {ok, {{one_for_one, 10, 60},
           Children ++ CrashLog

--- a/test/lager_app_tests.erl
+++ b/test/lager_app_tests.erl
@@ -5,18 +5,11 @@
 -include_lib("eunit/include/eunit.hrl").
 
 
-get_env_default_test() ->
-    ?assertEqual(<<"Some">>,  lager_app:get_env_default(undefined,         <<"Some">>)),
-    ?assertEqual(<<"Value">>, lager_app:get_env_default({ok, <<"Value">>}, <<"Some">>)),
-    ok.
-
 get_env_test() ->
     application:set_env(myapp, mykey1, <<"Value">>),
 
     ?assertEqual(<<"Some">>,  lager_app:get_env(myapp, mykey0, <<"Some">>)),
     ?assertEqual(<<"Value">>, lager_app:get_env(myapp, mykey1, <<"Some">>)),
 
-    ?assertEqual(undefined,   lager_app:get_env(myapp, mykey0)),
-    ?assertEqual(<<"Value">>, lager_app:get_env(myapp, mykey1)),
     ok.
 

--- a/test/lager_test_backend.erl
+++ b/test/lager_test_backend.erl
@@ -146,19 +146,6 @@ print_state(Sink) ->
 print_bad_state(Sink) ->
     gen_event:call(Sink, ?MODULE, print_bad_state).
 
-
-has_line_numbers() ->
-    %% are we R15 or greater
-    % this gets called a LOT - cache the answer
-    case erlang:get({?MODULE, has_line_numbers}) of
-        undefined ->
-            R = lager_util:otp_version() >= 15,
-            erlang:put({?MODULE, has_line_numbers}, R),
-            R;
-        Bool ->
-            Bool
-    end.
-
 not_running_test() ->
     ?assertEqual({error, lager_not_running}, lager:log(info, self(), "not running")).
 
@@ -901,45 +888,40 @@ crash(Type) ->
     ok.
 
 test_body(Expected, Actual) ->
-    case has_line_numbers() of
+    ExLen = length(Expected),
+    {Body, Rest} = case length(Actual) > ExLen of
         true ->
-            ExLen = length(Expected),
-            {Body, Rest} = case length(Actual) > ExLen of
-                true ->
-                    {string:substr(Actual, 1, ExLen),
-                        string:substr(Actual, (ExLen + 1))};
-                _ ->
-                    {Actual, []}
-            end,
-            ?assertEqual(Expected, Body),
-            % OTP-17 (and maybe later releases) may tack on additional info
-            % about the failure, so if Actual starts with Expected (already
-            % confirmed by having gotten past assertEqual above) and ends
-            % with " line NNN" we can ignore what's in-between. By extension,
-            % since there may not be line information appended at all, any
-            % text we DO find is reportable, but not a test failure.
-            case Rest of
-                [] ->
-                    ok;
-                _ ->
-                    % isolate the extra data and report it if it's not just
-                    % a line number indicator
-                    case re:run(Rest, "^.*( line \\d+)$", [{capture, [1]}]) of
-                        nomatch ->
-                            ?debugFmt(
-                                "Trailing data \"~s\" following \"~s\"",
-                                [Rest, Expected]);
-                        {match, [{0, _}]} ->
-                            % the whole sting is " line NNN"
-                            ok;
-                        {match, [{Off, _}]} ->
-                            ?debugFmt(
-                                "Trailing data \"~s\" following \"~s\"",
-                                [string:substr(Rest, 1, Off), Expected])
-                    end
-            end;
+            {string:substr(Actual, 1, ExLen),
+                string:substr(Actual, (ExLen + 1))};
         _ ->
-            ?assertEqual(Expected, Actual)
+            {Actual, []}
+    end,
+    ?assertEqual(Expected, Body),
+    % OTP-17 (and maybe later releases) may tack on additional info
+    % about the failure, so if Actual starts with Expected (already
+    % confirmed by having gotten past assertEqual above) and ends
+    % with " line NNN" we can ignore what's in-between. By extension,
+    % since there may not be line information appended at all, any
+    % text we DO find is reportable, but not a test failure.
+    case Rest of
+        [] ->
+            ok;
+        _ ->
+            % isolate the extra data and report it if it's not just
+            % a line number indicator
+            case re:run(Rest, "^.*( line \\d+)$", [{capture, [1]}]) of
+                nomatch ->
+                    ?debugFmt(
+                       "Trailing data \"~s\" following \"~s\"",
+                       [Rest, Expected]);
+                {match, [{0, _}]} ->
+                    % the whole sting is " line NNN"
+                    ok;
+                {match, [{Off, _}]} ->
+                    ?debugFmt(
+                       "Trailing data \"~s\" following \"~s\"",
+                       [string:substr(Rest, 1, Off), Expected])
+            end
     end.
 
 error_logger_redirect_crash_setup() ->


### PR DESCRIPTION
Fixes #399 

Perhaps the comments for https://github.com/erlang-lager/lager/blob/master/src/error_logger_lager_h.erl#L403 and https://github.com/erlang-lager/lager/blob/master/src/error_logger_lager_h.erl#L477 need updating but aside from that I think I've got it all.

geas output

```
~/src/lager (remove-r15) $ rebar3 geas
===> Verifying dependencies...
===> Compiling lager
   R15                   20.2       Geas database
---Min--------Arch-------Max----------------------------------------------------
                                    goldrush
   17.0                             lager
                                    goldrush
   17.0                             lager
   17.0                             lager
--------------------------------------------------------------------------------
   17.0                  20.2       Global project

./_build/default/lib/lager/ebin/error_logger_lager_h.beam
R16B      application:get_env/3

./_build/default/lib/lager/ebin/lager.beam
R16B01    lists:filtermap/2

./_build/default/lib/lager/ebin/lager_app.beam
R16B      application:get_env/3

./_build/default/lib/lager/ebin/lager_stdlib.beam
R16B      application:get_env/3

./_build/default/lib/lager/ebin/lager_sup.beam
R16B      application:get_env/3

./_build/default/lib/lager/ebin/lager_trunc_io.beam
17.0      erlang:map_size/1

./_build/test/lib/lager/ebin/error_logger_lager_h.beam
R16B      application:get_env/3

./_build/test/lib/lager/ebin/lager.beam
R16B01    lists:filtermap/2

./_build/test/lib/lager/ebin/lager_app.beam
R16B      application:get_env/3

./_build/test/lib/lager/ebin/lager_stdlib.beam
R16B      application:get_env/3

./_build/test/lib/lager/ebin/lager_sup.beam
R16B      application:get_env/3

./_build/test/lib/lager/ebin/lager_trunc_io.beam
17.0      erlang:map_size/1

./_build/test/lib/lager/ebin/lager_util.beam
R16B      file:list_dir_all/1

./_build/test/lib/lager/test/crash.beam
18.0      proc_lib:stop/1

./_build/test/lib/lager/test/lager_test_function_transform.beam
18.0      erlang:monotonic_time/0
```