### PR TITLE
Make a few corrections to the recent mailbox flushing changes

### DIFF
--- a/src/error_logger_lager_h.erl
+++ b/src/error_logger_lager_h.erl
@@ -72,7 +72,7 @@ set_high_water(N) ->
 
 -spec init(any()) -> {ok, #state{}}.
 init([HighWaterMark, GlStrategy]) ->
-    Flush = application:get_env(lager, error_logger_flush_queue, false),
+    Flush = application:get_env(lager, error_logger_flush_queue, true),
     FlushThr = application:get_env(lager, error_logger_flush_threshold, 0),
     Shaper = #lager_shaper{hwm=HighWaterMark, flush_queue = Flush, flush_threshold = FlushThr, filter=shaper_fun(), id=?MODULE},
     Raw = application:get_env(lager, error_logger_format_raw, false),

--- a/src/lager_util.erl
+++ b/src/lager_util.erl
@@ -515,7 +515,7 @@ check_hwm(Shaper = #lager_shaper{lasttime = Last, dropped = Drop}) ->
                            true ->
                                discard_messages(Now, Shaper#lager_shaper.filter, 0);
                            false ->
-                               1
+                               0
                        end,
             Timer = case erlang:read_timer(Shaper#lager_shaper.timer) of
                         false ->
@@ -534,7 +534,9 @@ should_flush(#lager_shaper{flush_queue = true, flush_threshold = 0}) ->
     true;
 should_flush(#lager_shaper{flush_queue = true, flush_threshold = T}) ->
     {_, L} = process_info(self(), message_queue_len),
-    L > T.
+    L > T;
+should_flush(_) ->
+    false.
 
 discard_messages(Second, Filter, Count) ->
     {M, S, _} = os:timestamp(),


### PR DESCRIPTION
Turns out that previous shaper PR I merged was not quite baked, sorry.

* `should_flush` was case_clausing
* the default for error_logger queue flushing was not set to true
* the dropped message count was being incorrectly incremented

If this looks good, we should cut a patch release ASAP @mrallen1 