### PR TITLE
OTP 21 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: erlang
 otp_release:
+  - 21.0-rc2
   - 20.0
   - 19.3
   - 18.3

--- a/rebar.config
+++ b/rebar.config
@@ -21,7 +21,7 @@
 
 {erl_opts, [
     {lager_extra_sinks, ['__lager_test_sink']},
-    {platform_define, "(19|20)", test_statem},
+    {platform_define, "(19|20|21)", test_statem},
     {platform_define, "(18)", 'FUNCTION_NAME', unavailable},
     {platform_define, "(18)", 'FUNCTION_ARITY', 0},
     debug_info,


### PR DESCRIPTION
To support OTP 21 we manually start error_logger if it is not present
(and lager is configured to install an error_logger handler) and we add
error_logger as a logger handler.

Longer term we should switch to installing our own logger handler, but
that is a larger task as we'd have to redo all the event parsing, if
that is even possible.

Related to #455 