### PR TITLE
Fix (dirty) for OTP 21

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -21,7 +21,8 @@
 
 {erl_opts, [
     {lager_extra_sinks, ['__lager_test_sink']},
-    {platform_define, "(19|20)", test_statem},
+    {platform_define, "(21)", new_logging_api},
+    {platform_define, "(19|20|21)", test_statem},
     {platform_define, "(18)", 'FUNCTION_NAME', unavailable},
     {platform_define, "(18)", 'FUNCTION_ARITY', 0},
     debug_info,

--- a/src/lager_app.erl
+++ b/src/lager_app.erl
@@ -205,12 +205,27 @@ get_env(Application, Key, Default) ->
     application:get_env(Application, Key, Default).
 
 start(_StartType, _StartArgs) ->
+    otp_21_plus_workaround(),
     {ok, Pid} = lager_sup:start_link(),
     SavedHandlers = boot(),
     _ = boot('__all_extra'),
     _ = boot('__traces'),
     clean_up_config_checks(),
     {ok, Pid, SavedHandlers}.
+
+-ifdef(new_logging_api).
+
+otp_21_plus_workaround() ->
+    %% OTP 21 doesn't start it by default
+    error_logger:start(),
+    logger:add_handler(error_logger, error_logger, #{level=>info,filter_default=>log}).
+
+-else.
+
+otp_21_plus_workaround() ->
+    no_workaround_needed.
+
+-endif.
 
 boot() ->
     %% Handle the default sink.


### PR DESCRIPTION
This fixes `error_logger` integration for OTP 21. The current test suite passes (some errors logs may be seen on RC1 but RC2 works perfectly).

It is not a definite fix and should be replaced with proper `logger` integration in the future.