### PR TITLE
Fixed platform_define pattern matching

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -21,9 +21,9 @@
 
 {erl_opts, [
     {lager_extra_sinks, ['__lager_test_sink']},
-    {platform_define, "(19|20|21)", test_statem},
-    {platform_define, "(18)", 'FUNCTION_NAME', unavailable},
-    {platform_define, "(18)", 'FUNCTION_ARITY', 0},
+    {platform_define, "^(19|20|21)", test_statem},
+    {platform_define, "^18", 'FUNCTION_NAME', unavailable},
+    {platform_define, "^18", 'FUNCTION_ARITY', 0},
     debug_info,
     report,
     verbose,


### PR DESCRIPTION
Rebar's internal mechanism for matching the `platform_define` config option could match against the full system architecture in addition to the OTP release version.
```
1> rebar_utils:get_arch()
"20.3.8-x86_64-apple-darwin18.0.0-64"
```

On the latest macOS kernel (architecture string above), the `platform_define` case in rebar.config:
```
{platform_define, "(18)", 'FUNCTION_NAME', unavailable},
```
would match, causing the FUNCTION_NAME macro to be redefined and prevent compilation with the following error:
```
===> Compiling lager
/Users/howard/Documents/erlang/nexthaul/_build/default/lib/lager/src/lager_util.erl: redefining predefined macro 'FUNCTION_NAME'
===> Compiling _build/default/lib/lager/src/lager_util.erl failed
_build/default/lib/lager/src/lager_util.erl:none: redefining predefined macro 'FUNCTION_NAME'
```

Forcing the pattern to match to the beginning of the platform_define fixes this issue.

Note: This is not an _immediate_ issue but will become an issue when Mojave is officially released. Currently this affects the macOS Mojave Beta as that is the only version of macOS to ship with the latest darwin kernel.