### PR TITLE
Prevent silent dropping of messages when hwm is exceeded

### DIFF
--- a/src/error_logger_lager_h.erl
+++ b/src/error_logger_lager_h.erl
@@ -121,8 +121,8 @@ handle_event(Event, #state{sink=Sink, shaper=Shaper} = State) ->
                 "lager_error_logger_h dropped ~p messages in the last second that exceeded the limit of ~p messages/sec",
                 [Drop, Hwm]),
             eval_gl(Event, State#state{shaper=NewShaper});
-        {false, _, NewShaper} ->
-            {ok, State#state{shaper=NewShaper}}
+        {false, _, #lager_shaper{dropped=D} = NewShaper} ->
+            {ok, State#state{shaper=NewShaper#lager_shaper{dropped=D+1}}}
     end.
 
 handle_info({shaper_expired, ?MODULE}, #state{sink=Sink, shaper=Shaper} = State) ->

--- a/src/lager_file_backend.erl
+++ b/src/lager_file_backend.erl
@@ -179,8 +179,8 @@ handle_event({log, Message},
                     {ok,write(NewState#state{shaper=NewShaper},
                         lager_msg:timestamp(Message), lager_msg:severity_as_int(Message),
                         Formatter:format(Message,FormatConfig))};
-                {false, _, NewShaper} ->
-                    {ok, State#state{shaper=NewShaper}}
+                {false, _, #lager_shaper{dropped=D} = NewShaper} ->
+                    {ok, State#state{shaper=NewShaper#lager_shaper{dropped=D+1}}}
             end;
         false ->
             {ok, State}


### PR DESCRIPTION
I noticed that when flush_queue is switched off and hwm is exceeded messages are just silently dropped without any warning. I tried to fix this.
