### PR TITLE
Fix markup - inline code

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,9 +360,9 @@ It is probably best to keep this number small.
 
 When the high-water mark is exceeded, lager can be configured to flush all
 event notifications in the message queue. This can have unintended consequences
-for other handlers in the same event manager (in e.g. the `error_logger'), as
+for other handlers in the same event manager (in e.g. the `error_logger`), as
 events they rely on may be wrongly discarded. By default, this behavior is enabled,
-but can be controlled, for the `error_logger' via:
+but can be controlled, for the `error_logger` via:
 
 ```erlang
 {error_logger_flush_queue, true | false}


### PR DESCRIPTION
It fixes this wring markup formatting:

<img width="944" alt="screen shot 2018-08-28 at 21 48 59" src="https://user-images.githubusercontent.com/14317604/44746985-41669800-ab0c-11e8-8f5f-d5f1939c728f.png">

The result:

<img width="944" alt="screen shot 2018-08-28 at 21 52 32" src="https://user-images.githubusercontent.com/14317604/44747138-b20db480-ab0c-11e8-9e1f-c39db697bb7e.png">
