### PR TITLE
Allow the console backend to redirect output to a remote node

### DIFF
--- a/README.md
+++ b/README.md
@@ -981,6 +981,32 @@ You can remove the trace when you're done by doing:
 lager:remove_trace(Pid).
 ```
 
+Console output to another group leader process
+----------------------------------------------
+
+If you want to send your console output to another group_leader (typically on
+another node) you can provide a `{group_leader, Pid}` argument to the console
+backend. This can be combined with another console config option, `id` and
+gen_event's `{Module, ID}` to allow remote tracing of a node to standard out via
+nodetool:
+
+```erlang
+    GL = erlang:group_leader(),
+    Node = node(GL),
+    lager_app:start_handler(lager_event, {lager_console_backend, Node},
+         [{group_leader, GL}, {level, none}, {id, {lager_console_backend, Node}}]),
+    case lager:trace({lager_console_backend, Node}, Filter, Level) of
+         ...
+```
+
+In the above example, the code is assumed to be running via a `nodetool rpc`
+invocation so that the code is executing on the Erlang node, but the
+group_leader is that of the reltool node (eg. appname_maint_12345@127.0.0.1).
+
+If you intend to use tracing with this feature, make sure the second parameter
+to start_handler and the `id` parameter match. Thus when the custom gen_leader
+process exits, lager will remove any associated traces for that handler.
+
 Elixir Support
 --------------
 

--- a/src/lager.erl
+++ b/src/lager.erl
@@ -32,7 +32,7 @@
         rotate_handler/1, rotate_handler/2, rotate_sink/1, rotate_all/0,
         trace/2, trace/3, trace_file/2, trace_file/3, trace_file/4, trace_console/1, trace_console/2,
         install_trace/2, remove_trace/1, trace_func/3,
-        list_all_sinks/0, clear_all_traces/0, stop_trace/1, stop_trace/3, status/0,
+        list_all_sinks/0, clear_all_traces/0, clear_trace_by_destination/1, stop_trace/1, stop_trace/3, status/0,
         get_loglevel/1, get_loglevel/2, set_loglevel/2, set_loglevel/3, set_loglevel/4, get_loglevels/1,
         update_loglevel_config/1, posix_error/1, set_loghwm/2, set_loghwm/3, set_loghwm/4,
         safe_format/3, safe_format_chop/3, unsafe_format/2, dispatch_log/5, dispatch_log/7, dispatch_log/9,
@@ -335,6 +335,12 @@ clear_traces_by_sink(Sinks) ->
                                            {Level, []})
                   end,
                   Sinks).
+
+clear_trace_by_destination(ID) ->
+    Sinks = lists:sort(list_all_sinks()),
+    Traces = find_traces(Sinks),
+    [ stop_trace_int({Filter, Level, Destination}, Sink) || {Sink, {Filter, Level, Destination}} <- Traces, Destination == ID].
+
 
 clear_all_traces() ->
     Handlers = lager_config:global_get(handlers, []),


### PR DESCRIPTION
To support tracing to a console that is not the erlang node's *direct*
console introduce 2 additional options to the console backend:
`group_leader` and `id`. Group leader allows to use io:put_chars to send
the console output to a remote pid (eg. the group leader on a node
created by nodetool) and the ID allows multiple console backends to
exist simultaneously (for example {lager_console_backend, NodeName}).

Additionally, to support ephemeral console backends with associated
traces, if the console handler explicitly removes itself from the event
handler, remove any traces for that id.

To facilitate this, a new function has been added to the lager module:
`lager:clear_trace_by_destination/1`.