### PR TITLE
replace list comprehension with recursive invokation in pr/2

### DIFF
--- a/src/lager.erl
+++ b/src/lager.erl
@@ -577,8 +577,8 @@ pr(Record, Module, Options) when is_tuple(Record), is_atom(element(1, Record)), 
         error:undef ->
             Record
     end;
-pr(List, Module, Options) when is_list(List), is_list(Options) ->
-    [pr(Element, Module, Options) || Element <- List];
+pr([Head|Tail], Module, Options) when is_list(Options) ->
+    [pr(Head, Module, Options)|pr(Tail, Module, Options)];
 pr(Record, _, _) ->
     Record.
 

--- a/test/pr_composite_test.erl
+++ b/test/pr_composite_test.erl
@@ -38,3 +38,10 @@ list_of_records_test() ->
     ?assertEqual([{'$lager_record', a, [{field1, 1},{field2, a2}]},
                   {'$lager_record', a, [{field1, 2},{field2, a2}]}],
                  Pr_As).
+
+improper_list_test() ->
+    A = #a{field1 = [1|2], field2 = a2},
+    Pr_A = lager:pr(A, ?MODULE),
+    ?assertEqual({'$lager_record',a,
+                  [{field1,[1|2]},{field2,a2}]},
+                 Pr_A).


### PR DESCRIPTION
The list comprehension fail on improper lists, use a recursive
call into pr/2 instead.

Fixes #477.