### PR TITLE
Improve debug tracing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -973,6 +973,18 @@ function in a target process by doing
 lager:install_trace(Pid, notice).
 ```
 
+You can also customize the tracing somewhat:
+
+```erlang
+lager:install_trace(Pid, notice, [{count, 100}, {timeout, 5000}, {format_string, "my trace event ~p ~p"]}).
+```
+
+The trace options are currently:
+
+* timeout - how long the trace stays installed: `infinity` (the default) or a millisecond timeout
+* count - how many trace events to log: `infinity` (default) or a positive number
+* format_string - the format string to log the event with. *Must* have 2 format specifiers for the 2 parameters supplied.
+
 This will, on every 'system event' for an OTP process (usually inbound messages, replies
 and state changes) generate a lager message at the specified log level.
 
@@ -981,6 +993,14 @@ You can remove the trace when you're done by doing:
 ```erlang
 lager:remove_trace(Pid).
 ```
+
+If you want to start an OTP process with tracing enabled from the very beginning, you can do something like this:
+
+```erlang
+gen_server:start_link(mymodule, [], [{debug, [{install, {fun lager:trace_func/3, lager:trace_state(undefined, notice, [])}}]}]).
+```
+
+The third argument to the trace_state function is the Option list documented above.
 
 Console output to another group leader process
 ----------------------------------------------


### PR DESCRIPTION
By an unhappy accident, OTP21 added functionality for 'named' trace
functions. This has a pattern match that matches the old trace function
(a 2 tuple where the second element is itself a 2 tuple):

https://github.com/erlang/otp/pull/1781

This patch changes to using a versioned record (so we can extend the
tracing later if needed) and adds 3 more options to tracing; count,
timeout and format string.

Additionally, tracing an OTP process via start_link arguments is now
documented.