### PR TITLE
On non-Unix file systems, inode is zero.

### DIFF
--- a/src/lager_rotator_default.erl
+++ b/src/lager_rotator_default.erl
@@ -41,7 +41,7 @@ ensure_logfile(Name, FD, Inode, Buffer) ->
     case file:read_file_info(Name) of
         {ok, FInfo} ->
             Inode2 = FInfo#file_info.inode,
-            case Inode == Inode2 of
+            case Inode == Inode2 andalso FD /= undefined of
                 true ->
                     {ok, {FD, Inode, FInfo#file_info.size}};
                 false ->


### PR DESCRIPTION
On windows, file:read_file_info/1, inode == 0.