### PR TITLE
Fix rotation on Windows

### DIFF
--- a/src/lager_file_backend.erl
+++ b/src/lager_file_backend.erl
@@ -190,8 +190,8 @@ handle_event(_Event, State) ->
 
 %% @private
 handle_info({rotate, File}, #state{name=File,count=Count,date=Date,rotator=Rotator} = State) ->
-    _ = Rotator:rotate_logfile(File, Count),
     State1 = close_file(State),
+    _ = Rotator:rotate_logfile(File, Count),
     schedule_rotation(File, Date),
     {ok, State1};
 handle_info({shaper_expired, Name}, #state{shaper=Shaper, name=Name, formatter=Formatter, formatter_config=FormatConfig} = State) ->

--- a/src/lager_rotator_default.erl
+++ b/src/lager_rotator_default.erl
@@ -37,6 +37,8 @@ open_logfile(Name, Buffer) ->
         Z -> Z
     end.
 
+ensure_logfile(Name, undefined, _Inode, Buffer) ->
+    open_logfile(Name, Buffer);
 ensure_logfile(Name, FD, Inode, Buffer) ->
     case file:read_file_info(Name) of
         {ok, FInfo} ->
@@ -80,12 +82,15 @@ rotate_logfile(File, 0) ->
         Error ->
             Error
     end;
-rotate_logfile(File, 1) ->
-    _ = file:rename(File, File++".0"),
-    rotate_logfile(File, 0);
-rotate_logfile(File, Count) ->
-    _ = file:rename(File ++ "." ++ integer_to_list(Count - 2), File ++ "." ++ integer_to_list(Count - 1)),
-    rotate_logfile(File, Count - 1).
+rotate_logfile(File0, 1) ->
+    File1 = File0 ++ ".0",
+    _ = file:rename(File0, File1),
+    rotate_logfile(File0, 0);
+rotate_logfile(File0, Count) ->
+    File1 = File0 ++ "." ++ integer_to_list(Count - 2),
+    File2 = File0 ++ "." ++ integer_to_list(Count - 1),
+    _ = file:rename(File1, File2),
+    rotate_logfile(File0, Count - 1).
 
 -ifdef(TEST).
 


### PR DESCRIPTION
To reproduce -

* Install RabbitMQ 3.7.12 and Erlang 21.2 on Windows
* Start up RabbitMQ, and run `rabbitmqctl rotate_logs`
* You will see the log file rotated, but nothing ever gets logged to the new file

Windows requires that all handles to a file are closed prior to renaming the file, which is why I moved `close_file` prior to `Rotator:rotate_logfile`. What I also found is that subsequent calls to `lager_rotator_default:ensure_logfile` would always fail to open the file since, on Windows, `Inode` is always `0`.

Adding a function head that matches the `undefined` `FD` case will ensure that the file is opened, which I believe is what we want no matter the underlying OS.