### PR TITLE
Replace string:find/2 for compatibility with Erlang/OTP 19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,7 @@ otp_release:
   - 22.0
   - 21.1
   - 20.3
-
+matrix:
+  include:
+  - otp_release: 19.3
+    dist: trusty

--- a/src/lager.erl
+++ b/src/lager.erl
@@ -741,6 +741,6 @@ get_sink_handler_status_unicode_test() ->
 
 validate_status(File) ->
     Handler = {lager_file_backend, File},
-    Status = get_sink_handler_status(?DEFAULT_SINK, Handler, debug),
-    ?assertNotEqual(nomatch, string:find(Status, File)).
+    Status = unicode:characters_to_binary(get_sink_handler_status(?DEFAULT_SINK, Handler, debug)),
+    ?assertNotEqual(nomatch, binary:match(Status, unicode:characters_to_binary(File))).
 -endif.

--- a/test/pr_stacktrace_test.erl
+++ b/test/pr_stacktrace_test.erl
@@ -29,7 +29,7 @@ pr_stacktrace_throw_test() ->
             lager:pr_stacktrace(?GET_STACK(Stacktrace), {Class, Reason})
     end,
     Want = "pr_stacktrace_test:pr_stacktrace_throw_test/0 line 26\n    pr_stacktrace_test:make_throw/0 line 16\nthrow:{test,exception}",
-    ?assertNotEqual(nomatch, string:find(Got, Want)).
+    ?assertNotEqual(0, string:str(Got, Want)).
 
 pr_stacktrace_bad_arg_test() ->
     Got = try
@@ -39,7 +39,7 @@ pr_stacktrace_bad_arg_test() ->
             lager:pr_stacktrace(?GET_STACK(Stacktrace), {Class, Reason})
     end,
     Want = "pr_stacktrace_test:pr_stacktrace_bad_arg_test/0 line 36\n    pr_stacktrace_test:bad_arg/0 line 22\nerror:badarg",
-    ?assertNotEqual(nomatch, string:find(Got, Want)).
+    ?assertNotEqual(0, string:str(Got, Want)).
 
 pr_stacktrace_bad_arity_test() ->
     Got = try
@@ -49,7 +49,7 @@ pr_stacktrace_bad_arity_test() ->
             lager:pr_stacktrace(?GET_STACK(Stacktrace), {Class, Reason})
     end,
     Want = "pr_stacktrace_test:pr_stacktrace_bad_arity_test/0 line 46\n    lists:concat([], [])\nerror:undef",
-    ?assertNotEqual(nomatch, string:find(Got, Want)).
+    ?assertNotEqual(0, string:str(Got, Want)).
 
 pr_stacktrace_no_reverse_test() ->
     application:set_env(lager, reverse_pretty_stacktrace, false),
@@ -60,4 +60,4 @@ pr_stacktrace_no_reverse_test() ->
             lager:pr_stacktrace(?GET_STACK(Stacktrace), {Class, Reason})
     end,
     Want = "error:undef\n    lists:concat([], [])\n    pr_stacktrace_test:pr_stacktrace_bad_arity_test/0 line 57",
-    ?assertEqual(nomatch, string:find(Got, Want)).
+    ?assertEqual(0, string:str(Got, Want)).


### PR DESCRIPTION
Erlang/OTP 19 does not have string:find so replace it to compatable methods.