### PR TITLE
Fix some tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,8 @@ otp_release:
   - 23.0
   - 22.3
   - 21.3
+script:
+  - rebar3 --version
+  - erl -version
+  - rebar3 dialyzer
+  - rebar3 eunit

--- a/src/lager_util.erl
+++ b/src/lager_util.erl
@@ -32,7 +32,7 @@
 ]).
 
 -ifdef(TEST).
--export([create_test_dir/0, get_test_dir/0, delete_test_dir/0,
+-export([create_test_dir/0, get_test_dir/0, delete_test_dir/0, delete_test_dir/1,
          set_dir_permissions/2,
          safe_application_load/1,
          safe_write_file/2]).


### PR DESCRIPTION
I get odd crashes in OTP 22+23, related to the following:

```erlang
-        TestBody("gen_statem crash", crash_statem, crash, [], "gen_statem crash_statem in state state1 terminated with reason: no function clause matching crash_statem:handle"),
-        TestBody("gen_statem stop", crash_statem, stop, [explode], "gen_statem crash_statem in state state1 terminated with reason: explode"),
-        TestBody("gen_statem timeout", crash_statem, timeout, [], "gen_statem crash_statem in state state1 terminated with reason: timeout")
+        TestBody("gen_statem crash", crash_statem, crash, [], "gen_statem crash_statem in state state1 terminated with reason: {function_clause,handle_event_function}"),
+        TestBody("gen_statem stop", crash_statem, stop, [explode], "gen_statem crash_statem in state state1 terminated with reason: {explod"),
+        TestBody("gen_statem timeout", crash_statem, timeout, [], "gen_statem crash_statem in state state1 terminated with reason: {timeou")
```

Didn't investigate deeper, since I wanted to push this to understand if it's OK. (I wonder if the errors were there already?)