### PR TITLE
Allow log_root on crash_log

### DIFF
--- a/src/lager.app.src
+++ b/src/lager.app.src
@@ -30,6 +30,8 @@
 
             ]},
 
+            %% Where to write the logs
+            {log_root, "log"},
             %% Whether to write a crash log, and where. False means no crash logger.
             {crash_log, "crash.log"},
             %% Maximum size in bytes of events in the crash log - defaults to 65536

--- a/src/lager.app.src
+++ b/src/lager.app.src
@@ -31,7 +31,7 @@
             ]},
 
             %% Whether to write a crash log, and where. False means no crash logger.
-            {crash_log, "log/crash.log"},
+            {crash_log, "crash.log"},
             %% Maximum size in bytes of events in the crash log - defaults to 65536
             {crash_log_msg_size, 65536},
             %% Maximum size of the crash log in bytes, before its rotated, set

--- a/src/lager_app.erl
+++ b/src/lager_app.erl
@@ -41,11 +41,11 @@
 -define(DEFAULT_HANDLER_CONF,
         [{lager_console_backend, [{level, info}]},
          {lager_file_backend,
-          [{file, "log/error.log"}, {level, error},
+          [{file, "error.log"}, {level, error},
            {size, 10485760}, {date, "$D0"}, {count, 5}]
          },
          {lager_file_backend,
-          [{file, "log/console.log"}, {level, info},
+          [{file, "console.log"}, {level, info},
            {size, 10485760}, {date, "$D0"}, {count, 5}]
          }
         ]).

--- a/src/lager_sup.erl
+++ b/src/lager_sup.erl
@@ -78,11 +78,7 @@ decide_crash_log(undefined) ->
     [];
 decide_crash_log(false) ->
     [];
-decide_crash_log(File0) ->
-    File = case application:get_env(lager, log_root, undefined) of
-               undefined -> "log/" ++ File0;
-               LogRoot -> LogRoot ++ "/" ++ File0
-           end,
+decide_crash_log(File) ->
     MaxBytes = validate_positive(application:get_env(lager, crash_log_msg_size), 65536),
     RotationSize = validate_positive(application:get_env(lager, crash_log_size), 0),
     RotationCount = validate_positive(application:get_env(lager, crash_log_count), 0),

--- a/src/lager_sup.erl
+++ b/src/lager_sup.erl
@@ -78,7 +78,11 @@ decide_crash_log(undefined) ->
     [];
 decide_crash_log(false) ->
     [];
-decide_crash_log(File) ->
+decide_crash_log(File0) ->
+    File = case application:get_env(lager, log_root, undefined) of
+               undefined -> "log/" ++ File0;
+               LogRoot -> LogRoot ++ "/" ++ File0
+           end,
     MaxBytes = validate_positive(application:get_env(lager, crash_log_msg_size), 65536),
     RotationSize = validate_positive(application:get_env(lager, crash_log_size), 0),
     RotationCount = validate_positive(application:get_env(lager, crash_log_count), 0),


### PR DESCRIPTION
Since `crash.log` is assumed defined, by default (otherwise it has to be defined as `false` or `undefined` explicity - something I don't usually do), if I define `log_root` and not `crash_log`, I get `crash_log` as `"<myfolder>/log/crash.log"`.

I'd prefer to have `crash.log` directly in `<myfolder>`. The proposed solution aims for backward compatibility.

**Edit**: I guess the same could be applied to the `DEFAULT_HANDLER_CONF`, though not setting `handlers` is probably less common than not setting `crash_log`.