### PR TITLE
Adapt to OTP 24's Line v. {Line,Col} location

### DIFF
--- a/src/lager_transform.erl
+++ b/src/lager_transform.erl
@@ -267,8 +267,11 @@ handle_args(DefaultAttrs, Line, [Arg1, Arg2]) ->
 handle_args(DefaultAttrs, _Line, [Attrs, Format, Args]) ->
     {concat_lists(Attrs, DefaultAttrs), Format, Args}.
 
-make_varname(Prefix, Line) ->
-    list_to_atom(Prefix ++ atom_to_list(get(module)) ++ integer_to_list(Line)).
+make_varname(Prefix, Loc) ->
+    list_to_atom(Prefix ++ atom_to_list(get(module)) ++ integer_to_list(line_from_loc(Loc))).
+
+line_from_loc({Line, _Col}) -> Line;
+line_from_loc(Line) -> Line.
 
 %% concat 2 list ASTs by replacing the terminating [] in A with the contents of B
 concat_lists({var, Line, _Name}=Var, B) ->


### PR DESCRIPTION
Due to an [upcoming change](https://github.com/erlang/otp/pull/3006) to the way location gets reported by the compiler, `lager` executes with error in Erlang/OTP `master`. This pull request fixes the only place I saw this occurrence failing, though there may be others 🤷‍♂️.