### PR TITLE
Further adapt to OTP 24 + adopt GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+---
+name: build
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  ci:
+    name: >
+      Run checks and tests over ${{matrix.otp_vsn}} and ${{matrix.os}}
+    runs-on: ${{matrix.os}}
+    container:
+      image: erlang:${{matrix.otp_vsn}}
+      options: --user 1001
+    strategy:
+      matrix:
+        otp_vsn: [21.3, 22.3, 23.2]
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - run: rebar3 dialyzer
+      - run: rebar3 eunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-sudo: false
-language: erlang
-otp_release:
-  - 23.0
-  - 22.3
-  - 21.3

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ to provide a more traditional way to perform logging in an erlang application
 that plays nicely with traditional UNIX logging tools like logrotate and
 syslog.
 
-[Travis-CI](http://travis-ci.org/erlang-lager/lager) :: [![Build Status](https://travis-ci.org/erlang-lager/lager.svg?branch=master)]
+[![Build Status](https://github.com/erlang-lager/lager/workflows/build/badge.svg)](https://github.com/erlang-lager/lager)
 [![Hex pm](https://img.shields.io/hexpm/v/lager)](https://hex.pm/packages/lager)
 
 Features

--- a/rebar.config
+++ b/rebar.config
@@ -21,7 +21,6 @@
 
 {erl_opts, [
     {lager_extra_sinks, ['__lager_test_sink']},
-    {platform_define, "^(19|20|21|22|23|24)", test_statem},
     {platform_define, "^18", 'FUNCTION_NAME', unavailable},
     {platform_define, "^18", 'FUNCTION_ARITY', 0},
     debug_info,

--- a/rebar.config
+++ b/rebar.config
@@ -21,7 +21,7 @@
 
 {erl_opts, [
     {lager_extra_sinks, ['__lager_test_sink']},
-    {platform_define, "^(19|20|21|22)", test_statem},
+    {platform_define, "^(19|20|21|22|23|24)", test_statem},
     {platform_define, "^18", 'FUNCTION_NAME', unavailable},
     {platform_define, "^18", 'FUNCTION_ARITY', 0},
     debug_info,

--- a/src/lager.erl
+++ b/src/lager.erl
@@ -80,7 +80,7 @@ start(App) ->
     start_ok(App, application:start(App, permanent)).
 
 start_ok(_App, ok) -> ok;
-start_ok(_App, {error, {already_started, _App}}) -> ok;
+start_ok(App, {error, {already_started, App}}) -> ok;
 start_ok(App, {error, {not_started, Dep}}) ->
     ok = start(Dep),
     start(App);

--- a/src/lager_transform.erl
+++ b/src/lager_transform.erl
@@ -267,11 +267,8 @@ handle_args(DefaultAttrs, Line, [Arg1, Arg2]) ->
 handle_args(DefaultAttrs, _Line, [Attrs, Format, Args]) ->
     {concat_lists(Attrs, DefaultAttrs), Format, Args}.
 
-make_varname(Prefix, Loc) ->
-    list_to_atom(Prefix ++ atom_to_list(get(module)) ++ integer_to_list(line_from_loc(Loc))).
-
-line_from_loc({Line, _Col}) -> Line;
-line_from_loc(Line) -> Line.
+make_varname(Prefix, CallAnno) ->
+    list_to_atom(Prefix ++ atom_to_list(get(module)) ++ integer_to_list(erl_anno:line(CallAnno))).
 
 %% concat 2 list ASTs by replacing the terminating [] in A with the contents of B
 concat_lists({var, Line, _Name}=Var, B) ->

--- a/test/crash_statem.erl
+++ b/test/crash_statem.erl
@@ -1,6 +1,5 @@
 -module(crash_statem).
 %% we're only going to compile this on OTP 19+
--ifdef(test_statem).
 -behaviour(gen_statem).
 
 -export([
@@ -45,11 +44,3 @@ handle_event({call, _From}, timeout, _Arg, _Data) ->
     {keep_state_and_data, [{state_timeout, 0, timeout}]};
 handle_event({call, _From}, {stop, Reason}, state1, _Data) ->
     {stop, Reason}.
-
--else.
--export([start/0, crash/0]).
-
-start() -> ok.
-crash() -> ok.
-
--endif.

--- a/test/lager_test_backend.erl
+++ b/test/lager_test_backend.erl
@@ -305,18 +305,18 @@ lager_test_() ->
                         lager:info(Attr, "hello ~p", Args),
                         lager:info([{d, delta}, {g, gamma}], Fmt, Args),
                         ?assertEqual(6, count()),
-                        {_Level, _Time, Message, Metadata}  = pop(),
+                        {Level, _Time, Message, Metadata}  = pop(),
                         ?assertMatch([{a, alpha}, {b, beta}|_], Metadata),
                         ?assertEqual("hello", lists:flatten(Message)),
-                        {_Level, _Time2, Message2, _Metadata2}  = pop(),
+                        {Level, _Time2, Message2, _Metadata2}  = pop(),
                         ?assertEqual("hello world", lists:flatten(Message2)),
-                        {_Level, _Time3, Message3, _Metadata3}  = pop(),
+                        {Level, _Time3, Message3, _Metadata3}  = pop(),
                         ?assertEqual("format world", lists:flatten(Message3)),
-                        {_Level, _Time4, Message4, _Metadata4}  = pop(),
+                        {Level, _Time4, Message4, _Metadata4}  = pop(),
                         ?assertEqual("hello world", lists:flatten(Message4)),
-                        {_Level, _Time5, Message5, _Metadata5}  = pop(),
+                        {Level, _Time5, Message5, _Metadata5}  = pop(),
                         ?assertEqual("hello world", lists:flatten(Message5)),
-                        {_Level, _Time6, Message6, Metadata6}  = pop(),
+                        {Level, _Time6, Message6, Metadata6}  = pop(),
                         ?assertMatch([{d, delta}, {g, gamma}|_], Metadata6),
                         ?assertEqual("format world", lists:flatten(Message6)),
                         ok
@@ -335,18 +335,18 @@ lager_test_() ->
                         lager:info([{K, atom_to_list(V)} || {K, V} <- Attr], "hello ~p", [{atom, X} || X <- Args]),
                         lager:info([{d, delta}, {g, gamma}], Fmt, [{atom, X} || X <- Args]),
                         ?assertEqual(6, count()),
-                        {_Level, _Time, Message, Metadata}  = pop(),
+                        {Level, _Time, Message, Metadata}  = pop(),
                         ?assertMatch([{a, "alpha"}, {b, "beta"}|_], Metadata),
                         ?assertEqual("hello", lists:flatten(Message)),
-                        {_Level, _Time2, Message2, _Metadata2}  = pop(),
+                        {Level, _Time2, Message2, _Metadata2}  = pop(),
                         ?assertEqual("hello {atom,world}", lists:flatten(Message2)),
-                        {_Level, _Time3, Message3, _Metadata3}  = pop(),
+                        {Level, _Time3, Message3, _Metadata3}  = pop(),
                         ?assertEqual("format world", lists:flatten(Message3)),
-                        {_Level, _Time4, Message4, _Metadata4}  = pop(),
+                        {Level, _Time4, Message4, _Metadata4}  = pop(),
                         ?assertEqual("hello {atom,world}", lists:flatten(Message4)),
-                        {_Level, _Time5, Message5, _Metadata5}  = pop(),
+                        {Level, _Time5, Message5, _Metadata5}  = pop(),
                         ?assertEqual("hello {atom,world}", lists:flatten(Message5)),
-                        {_Level, _Time6, Message6, Metadata6}  = pop(),
+                        {Level, _Time6, Message6, Metadata6}  = pop(),
                         ?assertMatch([{d, delta}, {g, gamma}|_], Metadata6),
                         ?assertEqual("format {atom,world}", lists:flatten(Message6)),
                         ok
@@ -365,18 +365,18 @@ lager_test_() ->
                         lager:info(fun() -> get(attrs) end(), "hello ~p", get(args)),
                         lager:info([{d, delta}, {g, gamma}], get(format), get(args)),
                         ?assertEqual(6, count()),
-                        {_Level, _Time, Message, Metadata}  = pop(),
+                        {Level, _Time, Message, Metadata}  = pop(),
                         ?assertMatch([{a, alpha}, {b, beta}|_], Metadata),
                         ?assertEqual("hello", lists:flatten(Message)),
-                        {_Level, _Time2, Message2, _Metadata2}  = pop(),
+                        {Level, _Time2, Message2, _Metadata2}  = pop(),
                         ?assertEqual("hello world", lists:flatten(Message2)),
-                        {_Level, _Time3, Message3, _Metadata3}  = pop(),
+                        {Level, _Time3, Message3, _Metadata3}  = pop(),
                         ?assertEqual("format world", lists:flatten(Message3)),
-                        {_Level, _Time4, Message4, _Metadata4}  = pop(),
+                        {Level, _Time4, Message4, _Metadata4}  = pop(),
                         ?assertEqual("hello world", lists:flatten(Message4)),
-                        {_Level, _Time5, Message5, _Metadata5}  = pop(),
+                        {Level, _Time5, Message5, _Metadata5}  = pop(),
                         ?assertEqual("hello world", lists:flatten(Message5)),
-                        {_Level, _Time6, Message6, Metadata6}  = pop(),
+                        {Level, _Time6, Message6, Metadata6}  = pop(),
                         ?assertMatch([{d, delta}, {g, gamma}|_], Metadata6),
                         ?assertEqual("format world", lists:flatten(Message6)),
                         ok
@@ -393,18 +393,18 @@ lager_test_() ->
                         lager:info(Test#test.attrs, "hello ~p", Test#test.args),
                         lager:info([{d, delta}, {g, gamma}], Test#test.format, Test#test.args),
                         ?assertEqual(6, count()),
-                        {_Level, _Time, Message, Metadata}  = pop(),
+                        {Level, _Time, Message, Metadata}  = pop(),
                         ?assertMatch([{a, alpha}, {b, beta}|_], Metadata),
                         ?assertEqual("hello", lists:flatten(Message)),
-                        {_Level, _Time2, Message2, _Metadata2}  = pop(),
+                        {Level, _Time2, Message2, _Metadata2}  = pop(),
                         ?assertEqual("hello world", lists:flatten(Message2)),
-                        {_Level, _Time3, Message3, _Metadata3}  = pop(),
+                        {Level, _Time3, Message3, _Metadata3}  = pop(),
                         ?assertEqual("format world", lists:flatten(Message3)),
-                        {_Level, _Time4, Message4, _Metadata4}  = pop(),
+                        {Level, _Time4, Message4, _Metadata4}  = pop(),
                         ?assertEqual("hello world", lists:flatten(Message4)),
-                        {_Level, _Time5, Message5, _Metadata5}  = pop(),
+                        {Level, _Time5, Message5, _Metadata5}  = pop(),
                         ?assertEqual("hello world", lists:flatten(Message5)),
-                        {_Level, _Time6, Message6, Metadata6}  = pop(),
+                        {Level, _Time6, Message6, Metadata6}  = pop(),
                         ?assertMatch([{d, delta}, {g, gamma}|_], Metadata6),
                         ?assertEqual("format world", lists:flatten(Message6)),
                         ok
@@ -794,18 +794,18 @@ extra_sinks_test_() ->
                         ?TEST_SINK_NAME:info(Attr, "hello ~p", Args),
                         ?TEST_SINK_NAME:info([{d, delta}, {g, gamma}], Fmt, Args),
                         ?assertEqual(6, count(?TEST_SINK_EVENT)),
-                        {_Level, _Time, Message, Metadata}  = pop(?TEST_SINK_EVENT),
+                        {Level, _Time, Message, Metadata}  = pop(?TEST_SINK_EVENT),
                         ?assertMatch([{a, alpha}, {b, beta}|_], Metadata),
                         ?assertEqual("hello", lists:flatten(Message)),
-                        {_Level, _Time2, Message2, _Metadata2}  = pop(?TEST_SINK_EVENT),
+                        {Level, _Time2, Message2, _Metadata2}  = pop(?TEST_SINK_EVENT),
                         ?assertEqual("hello world", lists:flatten(Message2)),
-                        {_Level, _Time3, Message3, _Metadata3}  = pop(?TEST_SINK_EVENT),
+                        {Level, _Time3, Message3, _Metadata3}  = pop(?TEST_SINK_EVENT),
                         ?assertEqual("format world", lists:flatten(Message3)),
-                        {_Level, _Time4, Message4, _Metadata4}  = pop(?TEST_SINK_EVENT),
+                        {Level, _Time4, Message4, _Metadata4}  = pop(?TEST_SINK_EVENT),
                         ?assertEqual("hello world", lists:flatten(Message4)),
-                        {_Level, _Time5, Message5, _Metadata5}  = pop(?TEST_SINK_EVENT),
+                        {Level, _Time5, Message5, _Metadata5}  = pop(?TEST_SINK_EVENT),
                         ?assertEqual("hello world", lists:flatten(Message5)),
-                        {_Level, _Time6, Message6, Metadata6}  = pop(?TEST_SINK_EVENT),
+                        {Level, _Time6, Message6, Metadata6}  = pop(?TEST_SINK_EVENT),
                         ?assertMatch([{d, delta}, {g, gamma}|_], Metadata6),
                         ?assertEqual("format world", lists:flatten(Message6)),
                         ok
@@ -912,6 +912,9 @@ crash(Type) ->
     _ = gen_event:which_handlers(error_logger),
     ok.
 
+test_body({slice, Expected}, Actual) ->
+    SlicedActual = string:slice(Actual, 0, length(Expected)),
+    ?assertEqual(Expected, SlicedActual, {Actual, sliced_to, SlicedActual, is_not_a_member_of, Expected});
 test_body(Expected, Actual) ->
     ExLen = length(Expected),
     {Body, Rest} = case length(Actual) > ExLen of
@@ -1056,11 +1059,10 @@ crash_fsm_test_() ->
             }
         end,
 
-        TestBody("gen_fsm crash", crash_fsm, crash, [], "gen_fsm crash_fsm in state state1 terminated with reason: call to undefined function crash_fsm:state1/3 from gen_fsm:handle_msg/"),
-        TestBody("gen_statem crash", crash_statem, crash, [], "gen_statem crash_statem in state state1 terminated with reason: no function clause matching crash_statem:handle"),
-        TestBody("gen_statem stop", crash_statem, stop, [explode], "gen_statem crash_statem in state state1 terminated with reason: explode"),
-        TestBody("gen_statem timeout", crash_statem, timeout, [], "gen_statem crash_statem in state state1 terminated with reason: timeout")
-    ],
+        TestBody("gen_statem crash", crash_statem, crash, [], {slice, "gen_statem crash_statem in state state1 terminated with reason"}),
+        TestBody("gen_statem stop", crash_statem, stop, [explode], {slice, "gen_statem crash_statem in state state1 terminated with reason"}),
+        TestBody("gen_statem timeout", crash_statem, timeout, [], {slice, "gen_statem crash_statem in state state1 terminated with reason"})
+    ] ++ test_body_gen_fsm_crash(TestBody),
 
     {"FSM crash output tests", [
         {"Default sink",
@@ -1074,6 +1076,14 @@ crash_fsm_test_() ->
             fun crash_fsm_cleanup/1,
             Tests}}
     ]}.
+
+-if(?OTP_RELEASE < 23).
+test_body_gen_fsm_crash(TestBody) ->
+    [TestBody("gen_fsm crash", crash_fsm, crash, [], "gen_fsm crash_fsm in state state1 terminated with reason: call to undefined function crash_fsm:state1/3 from gen_fsm:handle_msg/")].
+-else.
+test_body_gen_fsm_crash(_TestBody) ->
+    [].
+-endif.
 
 error_logger_redirect_crash_test_() ->
     TestBody=fun(Name,CrashReason,Expected) ->

--- a/test/pr_stacktrace_test.erl
+++ b/test/pr_stacktrace_test.erl
@@ -2,14 +2,6 @@
 
 -compile([{parse_transform, lager_transform}]).
 
--ifdef(OTP_RELEASE). %% this implies 21 or higher
--define(EXCEPTION(Class, Reason, Stacktrace), Class:Reason:Stacktrace).
--define(GET_STACK(Stacktrace), Stacktrace).
--else.
--define(EXCEPTION(Class, Reason, _), Class:Reason).
--define(GET_STACK(_), erlang:get_stacktrace()).
--endif.
-
 -include_lib("eunit/include/eunit.hrl").
 
 make_throw() ->
@@ -25,8 +17,8 @@ pr_stacktrace_throw_test() ->
     Got = try
         make_throw()
     catch
-        ?EXCEPTION(Class, Reason, Stacktrace) ->
-            lager:pr_stacktrace(?GET_STACK(Stacktrace), {Class, Reason})
+        Class:Reason:Stacktrace ->
+            lager:pr_stacktrace(Stacktrace, {Class, Reason})
     end,
     Want = "pr_stacktrace_test:pr_stacktrace_throw_test/0 line 26\n    pr_stacktrace_test:make_throw/0 line 16\nthrow:{test,exception}",
     ?assertNotEqual(nomatch, string:find(Got, Want)).
@@ -35,8 +27,8 @@ pr_stacktrace_bad_arg_test() ->
     Got = try
         bad_arg()
     catch
-        ?EXCEPTION(Class, Reason, Stacktrace) ->
-            lager:pr_stacktrace(?GET_STACK(Stacktrace), {Class, Reason})
+        Class:Reason:Stacktrace ->
+            lager:pr_stacktrace(Stacktrace, {Class, Reason})
     end,
     Want = "pr_stacktrace_test:pr_stacktrace_bad_arg_test/0 line 36\n    pr_stacktrace_test:bad_arg/0 line 22\nerror:badarg",
     ?assertNotEqual(nomatch, string:find(Got, Want)).
@@ -45,8 +37,8 @@ pr_stacktrace_bad_arity_test() ->
     Got = try
         bad_arity()
     catch
-        ?EXCEPTION(Class, Reason, Stacktrace) ->
-            lager:pr_stacktrace(?GET_STACK(Stacktrace), {Class, Reason})
+        Class:Reason:Stacktrace ->
+            lager:pr_stacktrace(Stacktrace, {Class, Reason})
     end,
     Want = "pr_stacktrace_test:pr_stacktrace_bad_arity_test/0 line 46\n    lists:concat([], [])\nerror:undef",
     ?assertNotEqual(nomatch, string:find(Got, Want)).
@@ -56,8 +48,8 @@ pr_stacktrace_no_reverse_test() ->
     Got = try
         bad_arity()
     catch
-        ?EXCEPTION(Class, Reason, Stacktrace) ->
-            lager:pr_stacktrace(?GET_STACK(Stacktrace), {Class, Reason})
+        Class:Reason:Stacktrace ->
+            lager:pr_stacktrace(Stacktrace, {Class, Reason})
     end,
     Want = "error:undef\n    lists:concat([], [])\n    pr_stacktrace_test:pr_stacktrace_bad_arity_test/0 line 57",
     ?assertEqual(nomatch, string:find(Got, Want)).


### PR DESCRIPTION
This pull request builds on top of [my previous one](https://github.com/erlang-lager/lager/pull/537/files).

On the one hand, I prefer `erl_anno:line/1` to matching on an "opaque" structure, since this eases maintenance.

On the other hand, with a more recent version of OTP (from `master`), I got new warnings (introduced by new behaviour from https://github.com/erlang/otp/pull/2995), now fixed.

**Note**: this doesn't fundamentally change the way we handle the location, but it meant I was assuming that the format for that might not change, which might not be true (since OTP 24 isn't out yet).