### PR TITLE
Prevent "wrong" log location

### DIFF
--- a/src/lager_util.erl
+++ b/src/lager_util.erl
@@ -464,11 +464,11 @@ expand_path(RelPath) ->
                    {ok, LogRoot} when is_list(LogRoot) -> % Join relative path
                        %% check if the given RelPath contains LogRoot, if so, do not add
                        %% it again; see gh #304
-                       case string:str(filename:dirname(RelPath), LogRoot) of
-                           X when X > 0 ->
-                               RelPath;
-                           _Zero ->
-                               filename:join(LogRoot, RelPath)
+                       case filename:dirname(RelPath) of
+                           "." ->
+                               filename:join(LogRoot, RelPath);
+                           false ->
+                               RelPath
                        end;
                    undefined -> % No log_root given, keep relative path
                        RelPath


### PR DESCRIPTION
Currently, if `log_root` is e.g. `log` and `console.log` is not specified with a "folder", `log_root`'s value is not taken into account (give the nature of `src`).

This proposed approach does not, however, allow for e.g. `log/console.log` to be saved in `logs/log/console.log` (in case `log_root` is defined), but I believe that's not the common use; otherwise we might add a new option (always use `log_root`) that would allow for this mis-behaviour to occur.

---

Of course, to be perfectly strict, and do away with these workarounds, we'd always apply `log_root` as a prefix, independent of what is chosen as file name, since that's the semantics of `log_root`, it seems.