### PR TITLE
Log to log_root+..._log except if ..._log is absolute

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   ci:
     name: >
-      Run checks and tests over ${{matrix.otp_vsn}} and ${{matrix.os}}
+      Run Linux-based checks and tests over ${{matrix.otp_vsn}} and ${{matrix.os}}
     runs-on: ${{matrix.os}}
     container:
       image: erlang:${{matrix.otp_vsn}}
@@ -23,3 +23,23 @@ jobs:
       - uses: actions/checkout@v2
       - run: rebar3 dialyzer
       - run: rebar3 eunit
+  ci-windows:
+    name: >
+      Run Windows-based checks and tests over ${{matrix.otp_vsn}} and ${{matrix.os}}
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        otp_vsn: [23.2]
+        os: [windows-latest]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: gleam-lang/setup-erlang@v1.1.2
+      with:
+        otp-version: ${{matrix.otp_vsn}}
+      id: install_erlang
+    - run: wget https://s3.amazonaws.com/rebar3/rebar3 -OutFile rebar3
+      shell: powershell
+    - run: |
+        & "${{steps.install_erlang.outputs.erlpath}}\bin\escript.exe" rebar3 dialyzer
+    - run: |
+        & "${{steps.install_erlang.outputs.erlpath}}\bin\escript.exe" rebar3 eunit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,0 @@
-build: off
-
-test_script:
-  - escript ./rebar get-deps
-  - escript ./rebar compile
-  - escript ./rebar eunit
-
-deploy: false

--- a/test/pr_stacktrace_test.erl
+++ b/test/pr_stacktrace_test.erl
@@ -20,7 +20,7 @@ pr_stacktrace_throw_test() ->
         Class:Reason:Stacktrace ->
             lager:pr_stacktrace(Stacktrace, {Class, Reason})
     end,
-    Want = "pr_stacktrace_test:pr_stacktrace_throw_test/0 line 26\n    pr_stacktrace_test:make_throw/0 line 16\nthrow:{test,exception}",
+    Want = "pr_stacktrace_test:pr_stacktrace_throw_test/0 line 18\n    pr_stacktrace_test:make_throw/0 line 8\nthrow:{test,exception}",
     ?assertNotEqual(nomatch, string:find(Got, Want)).
 
 pr_stacktrace_bad_arg_test() ->
@@ -30,7 +30,7 @@ pr_stacktrace_bad_arg_test() ->
         Class:Reason:Stacktrace ->
             lager:pr_stacktrace(Stacktrace, {Class, Reason})
     end,
-    Want = "pr_stacktrace_test:pr_stacktrace_bad_arg_test/0 line 36\n    pr_stacktrace_test:bad_arg/0 line 22\nerror:badarg",
+    Want = "pr_stacktrace_test:pr_stacktrace_bad_arg_test/0 line 28\n    pr_stacktrace_test:bad_arg/0 line 14\nerror:badarg",
     ?assertNotEqual(nomatch, string:find(Got, Want)).
 
 pr_stacktrace_bad_arity_test() ->
@@ -40,7 +40,7 @@ pr_stacktrace_bad_arity_test() ->
         Class:Reason:Stacktrace ->
             lager:pr_stacktrace(Stacktrace, {Class, Reason})
     end,
-    Want = "pr_stacktrace_test:pr_stacktrace_bad_arity_test/0 line 46\n    lists:concat([], [])\nerror:undef",
+    Want = "pr_stacktrace_test:pr_stacktrace_bad_arity_test/0 line 38\n    lists:concat([], [])\nerror:undef",
     ?assertNotEqual(nomatch, string:find(Got, Want)).
 
 pr_stacktrace_no_reverse_test() ->


### PR DESCRIPTION
This is a proposed fix that hopefully closes #542.~~, to get early feedback.~~

Apart from the obvious variable re-naming (it's not a rel. path anymore), I went with the approach described [here](https://github.com/erlang-lager/lager/issues/542#issuecomment-786599680).

I also prevent the `application:get_env` from being called when it's not required. Mind you, this is untested still.

---

**Edit**: what's done?
- [x] fix the issue described in https://github.com/erlang-lager/lager/issues/542#issue-817131138
- [x] implement the comment described in https://github.com/erlang-lager/lager/issues/542#issuecomment-786599680
- [x] fix previously existing test issues (from `master`)
- [x] remove `appveyor.yml`
- [x] add Windows GitHub Actions for OTP 23.2