### PR TITLE
add support settings to specify multiple logging levels

### DIFF
--- a/src/lager.erl
+++ b/src/lager.erl
@@ -440,17 +440,17 @@ get_sink_handler_status(Sink, Handler, Level) ->
     end.
 
 %% @doc Set the loglevel for a particular backend.
-set_loglevel(Handler, Level) when is_atom(Level) ->
+set_loglevel(Handler, Level) when is_atom(Level); is_list(Level) ->
     set_loglevel(?DEFAULT_SINK, Handler, undefined, Level).
 
 %% @doc Set the loglevel for a particular backend that has multiple identifiers
 %% (eg. the file backend).
-set_loglevel(Handler, Ident, Level) when is_atom(Level) ->
+set_loglevel(Handler, Ident, Level) when is_atom(Level); is_list(Level) ->
     set_loglevel(?DEFAULT_SINK, Handler, Ident, Level).
 
 %% @doc Set the loglevel for a particular sink's backend that potentially has
 %% multiple identifiers. (Use `undefined' if it doesn't have any.)
-set_loglevel(Sink, Handler, Ident, Level) when is_atom(Level) ->
+set_loglevel(Sink, Handler, Ident, Level) when is_atom(Level); is_list(Level) ->
     HandlerArg = case Ident of
         undefined -> Handler;
         _ -> {Handler, Ident}

--- a/src/lager_console_backend.erl
+++ b/src/lager_console_backend.erl
@@ -586,6 +586,8 @@ set_loglevel_test_() ->
                         ?assertEqual(info, lager:get_loglevel(lager_console_backend)),
                         lager:set_loglevel(lager_console_backend, '!=info'),
                         ?assertEqual(debug, lager:get_loglevel(lager_console_backend)),
+                        lager:set_loglevel(lager_console_backend, [debug, info]),
+                        ?assertEqual(debug, lager:get_loglevel(lager_console_backend)),
                         ok
                 end
             },

--- a/src/lager_util.erl
+++ b/src/lager_util.erl
@@ -98,9 +98,11 @@ mask_to_levels(Mask, [Level|Levels], Acc) ->
     end,
     mask_to_levels(Mask, Levels, NewAcc).
 
--spec config_to_levels(atom()|string()) -> [lager:log_level()].
+-spec config_to_levels(atom()|string()|[atom()]) -> [lager:log_level()].
 config_to_levels(Conf) when is_atom(Conf) ->
     config_to_levels(atom_to_list(Conf));
+config_to_levels([Level | _Rest] = Conf) when is_atom(Level) ->
+    lists:filter(fun(E) -> lists:member(E, Conf) end, levels());
 config_to_levels([$! | Rest]) ->
     levels() -- config_to_levels(Rest);
 config_to_levels([$=, $< | Rest]) ->


### PR DESCRIPTION
multiple log levels are supported for setting, like to
`{lager_file_backend,
    {file, "info.log"},
    **{level, [debug, error, notice]}**
}`
