### PR TITLE
Save state with new logfile handle when drop logs in shaper_expired

### DIFF
--- a/src/lager_rotator_default.erl
+++ b/src/lager_rotator_default.erl
@@ -56,7 +56,7 @@ reopen_logfile(Name, FD0, Buffer) ->
     _ = file:close(FD0),
     _ = file:close(FD0),
     case open_logfile(Name, Buffer) of
-        {ok, {_FD1, _Inode, _Size, _Ctime}=FileInfo} ->
+        {ok, {_FD1, _Inode, _Ctime, _Size}=FileInfo} ->
             %% inode changed, file was probably moved and
             %% recreated
             {ok, FileInfo};


### PR DESCRIPTION
There is a problem, when shaper expired and try drop logs, it can reopen log file, but doesn't save file handle. After this it reopen this file again, but first handle will never close, and old log file never delete from file system (until process dies)

Also try to escape edge-case bug: close reopened logfile with same name but new inode, when new file is exceed size limit. 