### PR TITLE
Fix logger:remove_handler() error check

### DIFF
--- a/src/lager_app.erl
+++ b/src/lager_app.erl
@@ -190,7 +190,7 @@ maybe_remove_logger_handler() ->
     try
         ok = logger:remove_handler(default)
     catch
-        error:undef -> ok;
+        error:{badmatch, {error, {badmatch, default}}} -> ok;
         Err:Reason ->
             error_logger:error_msg("calling logger:remove_handler(default) failed: ~p ~p",
                                    [Err, Reason])


### PR DESCRIPTION
It seems, from https://github.com/erlang-lager/lager/commit/9f8d7a705ef5e2e263f1b1b549ec8ba4d3f59a36
that the intent is to avoid logging an error when the default handler has already been removed, but the value it checks for is incorrect and can't ever be returned.

Erlang's logger:remove_handler() doesn't define a specific value in this case (or any case) but from the source it's clear that it will always be error:{badmatch, {error, {badmatch, <handler>}}} for the case where a handler isn't found, so look instead for this value.

This prevents a spurious error from being logged on every startup.