### PR TITLE
Suppress error when default logger handler already removed

### DIFF
--- a/src/lager_app.erl
+++ b/src/lager_app.erl
@@ -190,7 +190,8 @@ maybe_remove_logger_handler() ->
     try
         ok = logger:remove_handler(default)
     catch
-        error:undef -> ok;
+        error:undef -> ok; %% No remove_handler(), OTP < 21.1
+        error:{badmatch, {error, {not_found, default}}} -> ok; %% No default handler, already removed
         Err:Reason ->
             error_logger:error_msg("calling logger:remove_handler(default) failed: ~p ~p",
                                    [Err, Reason])


### PR DESCRIPTION
Erlang's logger:remove_handler() doesn't provide a specific error for the handler not existing, but the source indicates that it will always be:

{badmatch, {error, {not_found, default}}}

So suppress the error message in that specific case.
